### PR TITLE
Workaround rdar://19779978, Length detection array16/32, joinString-Method

### DIFF
--- a/MessagePack/Source/Helpers.swift
+++ b/MessagePack/Source/Helpers.swift
@@ -43,23 +43,18 @@ func joinUInt64<G: GeneratorType where G.Element == UInt8>(inout generator: G, s
     :returns: A `String`, or `nil` if the generator runs out of elements.
 */
 func joinString<G: GeneratorType where G.Element == UInt8>(inout generator: G, length: Int) -> String? {
-    let ptrCount = length + 1 // +1 for \0-termination
-    let ptr = UnsafeMutablePointer<CChar>.alloc(ptrCount)
-
-    for i in 0..<length {
+    var result = ""
+    
+    for _ in 0..<length {
         if let byte = generator.next() {
-            ptr[i] = CChar(bitPattern: byte)
-        } else {
-            ptr.dealloc(ptrCount)
+            result.append(Character(UnicodeScalar(byte)))
+        }
+        else {
             return nil
         }
     }
-    ptr[length] = 0
-
-    let string = String.fromCString(ptr)
-    ptr.dealloc(ptrCount)
-
-    return string
+    
+    return result
 }
 
 /**


### PR DESCRIPTION
Hi there,

I added some changes to my fork:

**1. Adding a fix for parsing negative fixint (workaround for rdar://19779978), same as in branch swift-2.0**
This is a fix for a known [bug in Swift 1.2](http://www.openradar.appspot.com/19779978). There´s already a workaround in the Swift 2.0 branch, but for some reason it wasn't used for the master?

**2. Simplified (and IMHO fixing the faulty one) length detection for array 16/32**
The length detection for array 16 and 32 doesn't work for us and with the [MessagePack Specification for arrays](https://github.com/msgpack/msgpack/blob/master/spec.md#formats-array) in mind, I guess this could be simplified as well: Array length is defined by either 2 or 4 bytes

**3. Simplified joinString-Method and using UTF-32 encoding**
I simplified the joinString-Method and in our case the UTF-32 encoding was necessary. Although in this case I'm not sure this work´s for everyone.
