### PR TITLE
Adding Bitcode Generation Mode

### DIFF
--- a/MessagePack.xcodeproj/project.pbxproj
+++ b/MessagePack.xcodeproj/project.pbxproj
@@ -657,6 +657,7 @@
 		838663111AAE0C9900FADC19 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = marker;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -673,6 +674,7 @@
 		838663121AAE0C9900FADC19 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;


### PR DESCRIPTION
Archiving our binary is currently no longer possible if we include your framework. 

```
 ld: bitcode bundle could not be generated because
 '/Users/hibento/Repositories/app/Carthage/Build/iOS/MessagePack.framework/MessagePack' 
 was built without full bitcode. All frameworks and dylibs for bitcode must be generated from Xcode Archive or Install build for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Adding the User defined Compiler Setting "BITCODE_GENERATION_MODE" we could solve this issue. See also [Carthage Issue 45](https://github.com/jspahrsummers/xcconfigs/issues/45)
