### PR TITLE
Swift syntax updates

### DIFF
--- a/MessagePack/DataGenerators.swift
+++ b/MessagePack/DataGenerators.swift
@@ -32,7 +32,7 @@ struct DispatchDataGenerator: GeneratorType {
             size = mapSize
         }
 
-        return buffer[i++ - offset]
+        let ret = buffer[i - offset]; i += 1; return ret
     }
 }
 
@@ -66,6 +66,6 @@ struct NSDataGenerator: GeneratorType {
             }
         }
 
-        return buffer[i++ - range.startIndex]
+        let ret = buffer[i - range.startIndex]; i += 1; return ret
     }
 }

--- a/MessagePack/DataGenerators.swift
+++ b/MessagePack/DataGenerators.swift
@@ -32,7 +32,9 @@ struct DispatchDataGenerator: GeneratorType {
             size = mapSize
         }
 
-        let ret = buffer[i - offset]; i += 1; return ret
+        let ret = buffer[i - offset]
+        i += 1
+        return ret
     }
 }
 
@@ -66,6 +68,8 @@ struct NSDataGenerator: GeneratorType {
             }
         }
 
-        let ret = buffer[i - range.startIndex]; i += 1; return ret
+        let ret = buffer[i - range.startIndex]
+        i += 1
+        return ret
     }
 }


### PR DESCRIPTION
Pre- and post-increment operators are deprectated and will be removed in Swift 3.0.
