### PR TITLE
Removed postincrement operator from Generator

### DIFF
--- a/MessagePack/DataGenerators.swift
+++ b/MessagePack/DataGenerators.swift
@@ -32,7 +32,9 @@ struct DispatchDataGenerator: GeneratorType {
             size = mapSize
         }
 
-        return buffer[i++ - offset]
+        let ret = buffer[i - offset]
+        i += 1
+        return ret
     }
 }
 
@@ -66,6 +68,8 @@ struct NSDataGenerator: GeneratorType {
             }
         }
 
-        return buffer[i++ - range.startIndex]
+        let ret = buffer[i - range.startIndex]
+        i += 1
+        return ret
     }
 }


### PR DESCRIPTION
Swift 2.2 deprecates postincrement and 3.0 removes it. 
This change fixes a deprecation warning under Swift 2.2.
