### PR TITLE
Added subscripted setters

### DIFF
--- a/MessagePackTests/ConveniencePropertiesTests.swift
+++ b/MessagePackTests/ConveniencePropertiesTests.swift
@@ -5,7 +5,7 @@ class ConveniencePropertiesTests: XCTestCase {
     func testCount() {
         XCTAssert(MessagePackValue.Array([0]).count == 1)
         XCTAssert(MessagePackValue.Map(["c": "cookie"]).count == 1)
-        XCTAssert(MessagePackValue.Nil.count == nil)
+        XCTAssert(MessagePackValue.Nil.count == 0)
     }
 
     func testIndexedSubscript() {


### PR DESCRIPTION
Enhanced subscript operators, providing setters for both .Map and
.Array style MessagePackValues.

Subscript operators now always return a MessagePackValue, if only just
a .Nil, allowing if-let-less traversal of nested MessagePackValue
enumerations.

Count now always returns a value  - 0 for non .Map or .Array types.
This provides the start of a path to adding CollectionType conformance
to the enumeration.
