### PR TITLE
Convert to Swift 3

### DIFF
--- a/MessagePack.xcodeproj/project.pbxproj
+++ b/MessagePack.xcodeproj/project.pbxproj
@@ -464,9 +464,11 @@
 					};
 					83CEDDA61ABDEBAF00664CC8 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					83CEDDB01ABDEBAF00664CC8 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					83D448881B5C8C4200B0F923 = {
 						CreatedOnToolsVersion = 7.0;
@@ -940,6 +942,7 @@
 				PRODUCT_NAME = MessagePack;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -962,6 +965,7 @@
 				PRODUCT_NAME = MessagePack;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -981,6 +985,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "us.pandamonia.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = MessagePackTests;
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -997,6 +1002,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "us.pandamonia.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = MessagePackTests;
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -1053,6 +1059,7 @@
 				1F7A01421C7B020E005F93F9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		1F7A01461C7B020E005F93F9 /* Build configuration list for PBXNativeTarget "MessagePackTests-tvOS" */ = {
 			isa = XCConfigurationList;
@@ -1061,6 +1068,7 @@
 				1F7A01441C7B020E005F93F9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8334F1B81B29FE9A00BDE13D /* Build configuration list for PBXNativeTarget "MessagePackTests-iOS" */ = {
 			isa = XCConfigurationList;

--- a/MessagePack.xcodeproj/xcshareddata/xcschemes/MessagePack-tvOS.xcscheme
+++ b/MessagePack.xcodeproj/xcshareddata/xcschemes/MessagePack-tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1F7A012F1C7B020E005F93F9"
-               BuildableName = "MessagePack-tvOS.framework"
+               BuildableName = "MessagePack.framework"
                BlueprintName = "MessagePack-tvOS"
                ReferencedContainer = "container:MessagePack.xcodeproj">
             </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1F7A01381C7B020E005F93F9"
-               BuildableName = "MessagePackTests-tvOS.xctest"
+               BuildableName = "MessagePackTests.xctest"
                BlueprintName = "MessagePackTests-tvOS"
                ReferencedContainer = "container:MessagePack.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1F7A012F1C7B020E005F93F9"
-            BuildableName = "MessagePack-tvOS.framework"
+            BuildableName = "MessagePack.framework"
             BlueprintName = "MessagePack-tvOS"
             ReferencedContainer = "container:MessagePack.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1F7A012F1C7B020E005F93F9"
-            BuildableName = "MessagePack-tvOS.framework"
+            BuildableName = "MessagePack.framework"
             BlueprintName = "MessagePack-tvOS"
             ReferencedContainer = "container:MessagePack.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1F7A012F1C7B020E005F93F9"
-            BuildableName = "MessagePack-tvOS.framework"
+            BuildableName = "MessagePack.framework"
             BlueprintName = "MessagePack-tvOS"
             ReferencedContainer = "container:MessagePack.xcodeproj">
          </BuildableReference>

--- a/MessagePack/ConvenienceInitializers.swift
+++ b/MessagePack/ConvenienceInitializers.swift
@@ -1,41 +1,41 @@
 extension MessagePackValue {
     public init() {
-        self = .Nil
+        self = .nil
     }
 
     public init(_ value: Swift.Bool) {
-        self = .Bool(value)
+        self = .bool(value)
     }
 
-    public init<S: SignedIntegerType>(_ value: S) {
-        self = .Int(numericCast(value))
+    public init<S: SignedInteger>(_ value: S) {
+        self = .int(numericCast(value))
     }
 
-    public init<U: UnsignedIntegerType>(_ value: U) {
-        self = .UInt(numericCast(value))
+    public init<U: UnsignedInteger>(_ value: U) {
+        self = .uInt(numericCast(value))
     }
 
     public init(_ value: Swift.Float) {
-        self = .Float(value)
+        self = .float(value)
     }
 
     public init(_ value: Swift.Double) {
-        self = .Double(value)
+        self = .double(value)
     }
 
     public init(_ value: Swift.String) {
-        self = .String(value)
+        self = .string(value)
     }
 
     public init(_ value: [MessagePackValue]) {
-        self = .Array(value)
+        self = .array(value)
     }
 
     public init(_ value: [MessagePackValue : MessagePackValue]) {
-        self = .Map(value)
+        self = .map(value)
     }
 
     public init(_ value: Data) {
-        self = .Binary(value)
+        self = .binary(value)
     }
 }

--- a/MessagePack/ConvenienceProperties.swift
+++ b/MessagePack/ConvenienceProperties.swift
@@ -2,9 +2,9 @@ extension MessagePackValue {
     /// The number of elements in the `.Array` or `.Map`, `nil` otherwise.
     public var count: Swift.Int? {
         switch self {
-        case let .Array(array):
+        case let .array(array):
             return array.count
-        case let .Map(dict):
+        case let .map(dict):
             return dict.count
         default:
             return nil
@@ -14,8 +14,8 @@ extension MessagePackValue {
     /// The element at subscript `i` in the `.Array`, `nil` otherwise.
     public subscript (i: Swift.Int) -> MessagePackValue? {
         switch self {
-        case let .Array(array):
-            return i < array.count ? array[i] : Optional.None
+        case let .array(array):
+            return i < array.count ? array[i] : Optional.none
         default:
             return nil
         }
@@ -24,7 +24,7 @@ extension MessagePackValue {
     /// The element at keyed subscript `key`, `nil` otherwise.
     public subscript (key: MessagePackValue) -> MessagePackValue? {
         switch self {
-        case let .Map(dict):
+        case let .map(dict):
             return dict[key]
         default:
             return nil
@@ -34,7 +34,7 @@ extension MessagePackValue {
     /// True if `.Nil`, false otherwise.
     public var isNil: Swift.Bool {
         switch self {
-        case .Nil:
+        case .nil:
             return true
         default:
             return false
@@ -44,9 +44,9 @@ extension MessagePackValue {
     /// The integer value if `.Int` or an appropriately valued `.UInt`, `nil` otherwise.
     public var integerValue: Int64? {
         switch self {
-        case let .Int(value):
+        case let .int(value):
             return value
-        case let .UInt(value) where value < numericCast(Swift.Int64.max):
+        case let .uInt(value) where value < numericCast(Swift.Int64.max):
             return numericCast(value) as Int64
         default:
             return nil
@@ -56,9 +56,9 @@ extension MessagePackValue {
     /// The unsigned integer value if `.UInt` or positive `.Int`, `nil` otherwise.
     public var unsignedIntegerValue: UInt64? {
         switch self {
-        case let .Int(value) where value >= 0:
+        case let .int(value) where value >= 0:
             return numericCast(value) as UInt64
-        case let .UInt(value):
+        case let .uInt(value):
             return value
         default:
             return nil
@@ -68,7 +68,7 @@ extension MessagePackValue {
     /// The contained array if `.Array`, `nil` otherwise.
     public var arrayValue: [MessagePackValue]? {
         switch self {
-        case let .Array(array):
+        case let .array(array):
             return array
         default:
             return nil
@@ -78,7 +78,7 @@ extension MessagePackValue {
     /// The contained boolean value if `.Bool`, `nil` otherwise.
     public var boolValue: Swift.Bool? {
         switch self {
-        case let .Bool(value):
+        case let .bool(value):
             return value
         default:
             return nil
@@ -88,9 +88,9 @@ extension MessagePackValue {
     /// The contained floating point value if `.Float` or `.Double`, `nil` otherwise.
     public var floatValue: Swift.Float? {
         switch self {
-        case let .Float(value):
+        case let .float(value):
             return value
-        case let .Double(value):
+        case let .double(value):
             return Swift.Float(value)
         default:
             return nil
@@ -100,9 +100,9 @@ extension MessagePackValue {
     /// The contained double-precision floating point value if `.Float` or `.Double`, `nil` otherwise.
     public var doubleValue: Swift.Double? {
         switch self {
-        case let .Float(value):
+        case let .float(value):
             return Swift.Double(value)
-        case let .Double(value):
+        case let .double(value):
             return value
         default:
             return nil
@@ -112,14 +112,14 @@ extension MessagePackValue {
     /// The contained string if `.String`, `nil` otherwise.
     public var stringValue: Swift.String? {
         switch self {
-        case .Binary(let data):
+        case .binary(let data):
             var result = ""
             result.reserveCapacity(data.count)
             for byte in data {
                 result.append(Character(UnicodeScalar(byte)))
             }
             return result
-        case let .String(string):
+        case let .string(string):
             return string
         default:
             return nil
@@ -129,9 +129,9 @@ extension MessagePackValue {
     /// The contained data if `.Binary` or `.Extended`, `nil` otherwise.
     public var dataValue: Data? {
         switch self {
-        case let .Binary(bytes):
+        case let .binary(bytes):
             return bytes
-        case let .Extended(_, data):
+        case let .extended(_, data):
             return data
         default:
             return nil
@@ -141,7 +141,7 @@ extension MessagePackValue {
     /// The contained type and data if Extended, `nil` otherwise.
     public var extendedValue: (Int8, Data)? {
         switch self {
-        case let .Extended(type, data):
+        case let .extended(type, data):
             return (type, data)
         default:
             return nil
@@ -151,7 +151,7 @@ extension MessagePackValue {
     /// The contained type if `.Extended`, `nil` otherwise.
     public var extendedType: Int8? {
         switch self {
-        case let .Extended(type, _):
+        case let .extended(type, _):
             return type
         default:
             return nil
@@ -161,7 +161,7 @@ extension MessagePackValue {
     /// The contained dictionary if `.Map`, `nil` otherwise.
     public var dictionaryValue: [MessagePackValue : MessagePackValue]? {
         switch self {
-        case let .Map(dict):
+        case let .map(dict):
             return dict
         default:
             return nil

--- a/MessagePack/LiteralConvertibles.swift
+++ b/MessagePack/LiteralConvertibles.swift
@@ -1,58 +1,58 @@
-extension MessagePackValue: ArrayLiteralConvertible {
+extension MessagePackValue: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: MessagePackValue...) {
-        self = .Array(elements)
+        self = .array(elements)
     }
 }
 
-extension MessagePackValue: BooleanLiteralConvertible {
+extension MessagePackValue: ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Swift.Bool) {
-        self = .Bool(value)
+        self = .bool(value)
     }
 }
 
-extension MessagePackValue: DictionaryLiteralConvertible {
+extension MessagePackValue: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (MessagePackValue, MessagePackValue)...) {
         var dict = [MessagePackValue : MessagePackValue](minimumCapacity: elements.count)
         for (key, value) in elements {
             dict[key] = value
         }
 
-        self = .Map(dict)
+        self = .map(dict)
     }
 }
 
-extension MessagePackValue: ExtendedGraphemeClusterLiteralConvertible {
+extension MessagePackValue: ExpressibleByExtendedGraphemeClusterLiteral {
     public init(extendedGraphemeClusterLiteral value: Swift.String) {
-        self = .String(value)
+        self = .string(value)
     }
 }
 
-extension MessagePackValue: FloatLiteralConvertible {
+extension MessagePackValue: ExpressibleByFloatLiteral {
     public init(floatLiteral value: Swift.Double) {
-        self = .Double(value)
+        self = .double(value)
     }
 }
 
-extension MessagePackValue: IntegerLiteralConvertible {
+extension MessagePackValue: ExpressibleByIntegerLiteral {
     public init(integerLiteral value: Int64) {
-        self = .Int(value)
+        self = .int(value)
     }
 }
 
-extension MessagePackValue: NilLiteralConvertible {
+extension MessagePackValue: ExpressibleByNilLiteral {
     public init(nilLiteral: ()) {
-        self = .Nil
+        self = .nil
     }
 }
 
-extension MessagePackValue: StringLiteralConvertible {
+extension MessagePackValue: ExpressibleByStringLiteral {
     public init(stringLiteral value: Swift.String) {
-        self = .String(value)
+        self = .string(value)
     }
 }
 
-extension MessagePackValue: UnicodeScalarLiteralConvertible {
+extension MessagePackValue: ExpressibleByUnicodeScalarLiteral {
     public init(unicodeScalarLiteral value: Swift.String) {
-        self = .String(value)
+        self = .string(value)
     }
 }

--- a/MessagePack/MessagePack.swift
+++ b/MessagePack/MessagePack.swift
@@ -3,64 +3,64 @@ public typealias Data = [Byte]
 
 /// The MessagePackValue enum encapsulates one of the following types: Nil, Bool, Int, UInt, Float, Double, String, Binary, Array, Map, and Extended.
 public enum MessagePackValue {
-    case Nil
-    case Bool(Swift.Bool)
-    case Int(Int64)
-    case UInt(UInt64)
-    case Float(Swift.Float)
-    case Double(Swift.Double)
-    case String(Swift.String)
-    case Binary(Data)
-    case Array([MessagePackValue])
-    case Map([MessagePackValue : MessagePackValue])
-    case Extended(Int8, Data)
+    case `nil`
+    case bool(Swift.Bool)
+    case int(Int64)
+    case uInt(UInt64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case string(Swift.String)
+    case binary(Data)
+    case array([MessagePackValue])
+    case map([MessagePackValue : MessagePackValue])
+    case extended(Int8, Data)
 }
 
 extension MessagePackValue: Hashable {
     public var hashValue: Swift.Int {
         switch self {
-        case .Nil: return 0
-        case .Bool(let value): return value.hashValue
-        case .Int(let value): return value.hashValue
-        case .UInt(let value): return value.hashValue
-        case .Float(let value): return value.hashValue
-        case .Double(let value): return value.hashValue
-        case .String(let string): return string.hashValue
-        case .Binary(let data): return data.count
-        case .Array(let array): return array.count
-        case .Map(let dict): return dict.count
-        case .Extended(let type, let data): return type.hashValue ^ data.count
+        case .nil: return 0
+        case .bool(let value): return value.hashValue
+        case .int(let value): return value.hashValue
+        case .uInt(let value): return value.hashValue
+        case .float(let value): return value.hashValue
+        case .double(let value): return value.hashValue
+        case .string(let string): return string.hashValue
+        case .binary(let data): return data.count
+        case .array(let array): return array.count
+        case .map(let dict): return dict.count
+        case .extended(let type, let data): return type.hashValue ^ data.count
         }
     }
 }
 
 public func ==(lhs: MessagePackValue, rhs: MessagePackValue) -> Bool {
     switch (lhs, rhs) {
-    case (.Nil, .Nil):
+    case (.nil, .nil):
         return true
-    case let (.Bool(lhv), .Bool(rhv)):
+    case let (.bool(lhv), .bool(rhv)):
         return lhv == rhv
-    case let (.Int(lhv), .Int(rhv)):
+    case let (.int(lhv), .int(rhv)):
         return lhv == rhv
-    case let (.UInt(lhv), .UInt(rhv)):
+    case let (.uInt(lhv), .uInt(rhv)):
         return lhv == rhv
-    case let (.Int(lhv), .UInt(rhv)):
+    case let (.int(lhv), .uInt(rhv)):
         return lhv >= 0 && numericCast(lhv) == rhv
-    case let (.UInt(lhv), .Int(rhv)):
+    case let (.uInt(lhv), .int(rhv)):
         return rhv >= 0 && lhv == numericCast(rhv)
-    case let (.Float(lhv), .Float(rhv)):
+    case let (.float(lhv), .float(rhv)):
         return lhv == rhv
-    case let (.Double(lhv), .Double(rhv)):
+    case let (.double(lhv), .double(rhv)):
         return lhv == rhv
-    case let (.String(lhv), .String(rhv)):
+    case let (.string(lhv), .string(rhv)):
         return lhv == rhv
-    case let (.Binary(lhv), .Binary(rhv)):
+    case let (.binary(lhv), .binary(rhv)):
         return lhv == rhv
-    case let (.Array(lhv), .Array(rhv)):
+    case let (.array(lhv), .array(rhv)):
         return lhv == rhv
-    case let (.Map(lhv), .Map(rhv)):
+    case let (.map(lhv), .map(rhv)):
         return lhv == rhv
-    case let (.Extended(lht, lhb), .Extended(rht, rhb)):
+    case let (.extended(lht, lhb), .extended(rht, rhb)):
         return lht == rht && lhb == rhb
     default:
         return false
@@ -70,38 +70,38 @@ public func ==(lhs: MessagePackValue, rhs: MessagePackValue) -> Bool {
 extension MessagePackValue: CustomStringConvertible {
     public var description: Swift.String {
         switch self {
-        case .Nil:
+        case .nil:
             return "Nil"
-        case let .Bool(value):
+        case let .bool(value):
             return "Bool(\(value))"
-        case let .Int(value):
+        case let .int(value):
             return "Int(\(value))"
-        case let .UInt(value):
+        case let .uInt(value):
             return "UInt(\(value))"
-        case let .Float(value):
+        case let .float(value):
             return "Float(\(value))"
-        case let .Double(value):
+        case let .double(value):
             return "Double(\(value))"
-        case let .String(string):
+        case let .string(string):
             return "String(\(string))"
-        case let .Binary(data):
+        case let .binary(data):
             return "Data(\(dataDescription(data)))"
-        case let .Array(array):
+        case let .array(array):
             return "Array(\(array.description))"
-        case let .Map(dict):
+        case let .map(dict):
             return "Map(\(dict.description))"
-        case let .Extended(type, data):
+        case let .extended(type, data):
             return "Extended(\(type), \(dataDescription(data)))"
         }
     }
 }
 
-public enum MessagePackError: ErrorType {
-    case InsufficientData
-    case InvalidData
+public enum MessagePackError: Error {
+    case insufficientData
+    case invalidData
 }
 
-func dataDescription(data: Data) -> String {
+func dataDescription(_ data: Data) -> String {
     let bytes = data.map { byte -> String in
         let prefix: String
         if byte < 0x10 {
@@ -113,5 +113,5 @@ func dataDescription(data: Data) -> String {
         return prefix + String(byte, radix: 16)
     }
 
-    return "[" + bytes.joinWithSeparator(", ") + "]"
+    return "[" + bytes.joined(separator: ", ") + "]"
 }

--- a/MessagePack/Pack.swift
+++ b/MessagePack/Pack.swift
@@ -4,9 +4,9 @@
 /// - parameter parts: The number of bytes into which to split.
 ///
 /// - returns: An byte array representation.
-func packInteger(value: UInt64, parts: Int) -> Data {
+func packInteger(_ value: UInt64, parts: Int) -> Data {
     precondition(parts > 0)
-    return (8 * (parts - 1)).stride(through: 0, by: -8).map { shift in
+    return stride(from: (8 * (parts - 1)), through: 0, by: -8).map { shift in
         return Byte(truncatingBitPattern: value >> numericCast(shift))
     }
 }
@@ -16,7 +16,7 @@ func packInteger(value: UInt64, parts: Int) -> Data {
 /// - parameter value: The value to encode
 ///
 /// - returns: A MessagePack byte representation.
-func packPositiveInteger(value: UInt64) -> Data {
+func packPositiveInteger(_ value: UInt64) -> Data {
     switch value {
     case let value where value <= 0x7f:
         return [Byte(truncatingBitPattern: value)]
@@ -36,7 +36,7 @@ func packPositiveInteger(value: UInt64) -> Data {
 /// - parameter value: The value to encode
 ///
 /// - returns: A MessagePack byte representation.
-func packNegativeInteger(value: Int64) -> Data {
+func packNegativeInteger(_ value: Int64) -> Data {
     precondition(value < 0)
 
     switch value {
@@ -61,33 +61,33 @@ func packNegativeInteger(value: Int64) -> Data {
 /// - parameter value: The value to encode
 ///
 /// - returns: A MessagePack byte representation.
-public func pack(value: MessagePackValue) -> Data {
+public func pack(_ value: MessagePackValue) -> Data {
     switch value {
-    case .Nil:
+    case .nil:
         return [0xc0]
 
-    case let .Bool(value):
+    case let .bool(value):
         return [value ? 0xc3 : 0xc2]
 
-    case let .Int(value):
+    case let .int(value):
         if value >= 0 {
             return packPositiveInteger(numericCast(value))
         } else {
             return packNegativeInteger(value)
         }
 
-    case let .UInt(value):
+    case let .uInt(value):
         return packPositiveInteger(value)
 
-    case let .Float(value):
-        let integerValue = unsafeBitCast(value, UInt32.self)
+    case let .float(value):
+        let integerValue = unsafeBitCast(value, to: UInt32.self)
         return [0xca] + packInteger(numericCast(integerValue), parts: 4)
 
-    case let .Double(value):
-        let integerValue = unsafeBitCast(value, UInt64.self)
+    case let .double(value):
+        let integerValue = unsafeBitCast(value, to: UInt64.self)
         return [0xcb] + packInteger(integerValue, parts: 8)
 
-    case let .String(string):
+    case let .string(string):
         let utf8 = string.utf8
         let count = UInt32(utf8.count)
         precondition(count <= 0xffff_ffff)
@@ -106,7 +106,7 @@ public func pack(value: MessagePackValue) -> Data {
 
         return prefix + utf8
 
-    case let .Binary(data):
+    case let .binary(data):
         let count = UInt32(data.count)
         precondition(count <= 0xffff_ffff)
 
@@ -122,7 +122,7 @@ public func pack(value: MessagePackValue) -> Data {
 
         return prefix + data
 
-    case let .Array(array):
+    case let .array(array):
         let count = UInt32(array.count)
         precondition(count <= 0xffff_ffff)
 
@@ -138,7 +138,7 @@ public func pack(value: MessagePackValue) -> Data {
 
         return prefix + array.flatMap(pack)
 
-    case let .Map(dict):
+    case let .map(dict):
         let count = UInt32(dict.count)
         precondition(count < 0xffff_ffff)
 
@@ -154,7 +154,7 @@ public func pack(value: MessagePackValue) -> Data {
 
         return prefix + dict.flatMap { [$0, $1] }.flatMap(pack)
 
-    case let .Extended(type, data):
+    case let .extended(type, data):
         let count = UInt32(data.count)
         precondition(count <= 0xffff_ffff)
 

--- a/MessagePack/Unpack.swift
+++ b/MessagePack/Unpack.swift
@@ -4,13 +4,13 @@
 /// - parameter size: The size of the integer.
 ///
 /// - returns: An integer representation of `size` bytes of data.
-func unpackInteger<G: GeneratorType where G.Element == Byte>(inout generator: G, size: Int) throws -> UInt64 {
+func unpackInteger<G: IteratorProtocol>(_ generator: inout G, size: Int) throws -> UInt64 where G.Element == Byte {
     var value: UInt64 = 0
     for _ in 0..<size {
         if let byte = generator.next() {
             value = value << 8 | numericCast(byte)
         } else {
-            throw MessagePackError.InsufficientData
+            throw MessagePackError.insufficientData
         }
     }
 
@@ -23,7 +23,7 @@ func unpackInteger<G: GeneratorType where G.Element == Byte>(inout generator: G,
 /// - parameter length: The length of the string.
 ///
 /// - returns: A string representation of `size` bytes of data.
-func unpackString<G: GeneratorType where G.Element == Byte>(inout generator: G, length: Int) throws -> String {
+func unpackString<G: IteratorProtocol>(_ generator: inout G, length: Int) throws -> String where G.Element == Byte {
     var bytes = Data()
     bytes.reserveCapacity(length)
 
@@ -31,14 +31,14 @@ func unpackString<G: GeneratorType where G.Element == Byte>(inout generator: G, 
         if let byte = generator.next() {
             bytes.append(byte)
         } else {
-            throw MessagePackError.InsufficientData
+            throw MessagePackError.insufficientData
         }
     }
 
-    if let result = String(bytes: bytes, encoding: NSUTF8StringEncoding) {
+    if let result = String(bytes: bytes, encoding: String.Encoding.utf8) {
         return result
     } else {
-        throw MessagePackError.InvalidData
+        throw MessagePackError.invalidData
     }
 }
 
@@ -48,7 +48,7 @@ func unpackString<G: GeneratorType where G.Element == Byte>(inout generator: G, 
 /// - parameter length: The length of the data.
 ///
 /// - returns: A subsection of data representing `size` bytes.
-func unpackData<G: GeneratorType where G.Element == Byte>(inout generator: G, length: Int) throws -> Data {
+func unpackData<G: IteratorProtocol>(_ generator: inout G, length: Int) throws -> Data where G.Element == Byte {
     var data = Data()
     data.reserveCapacity(length)
 
@@ -56,7 +56,7 @@ func unpackData<G: GeneratorType where G.Element == Byte>(inout generator: G, le
         if let byte = generator.next() {
             data.append(byte)
         } else {
-            throw MessagePackError.InsufficientData
+            throw MessagePackError.insufficientData
         }
     }
 
@@ -69,7 +69,7 @@ func unpackData<G: GeneratorType where G.Element == Byte>(inout generator: G, le
 /// - parameter count: The number of elements to unpack.
 ///
 /// - returns: An array of `count` elements.
-func unpackArray<G: GeneratorType where G.Element == Byte>(inout generator: G, count: Int, compatibility: Bool) throws -> [MessagePackValue] {
+func unpackArray<G: IteratorProtocol>(_ generator: inout G, count: Int, compatibility: Bool) throws -> [MessagePackValue] where G.Element == Byte {
     var values = [MessagePackValue]()
     values.reserveCapacity(count)
 
@@ -87,7 +87,7 @@ func unpackArray<G: GeneratorType where G.Element == Byte>(inout generator: G, c
 /// - parameter count: The number of elements to unpack.
 ///
 /// - returns: An dictionary of `count` entries.
-func unpackMap<G: GeneratorType where G.Element == Byte>(inout generator: G, count: Int, compatibility: Bool) throws -> [MessagePackValue : MessagePackValue] {
+func unpackMap<G: IteratorProtocol>(_ generator: inout G, count: Int, compatibility: Bool) throws -> [MessagePackValue : MessagePackValue] where G.Element == Byte {
     var dict = [MessagePackValue : MessagePackValue](minimumCapacity: count)
     var lastKey: MessagePackValue? = nil
 
@@ -109,56 +109,56 @@ func unpackMap<G: GeneratorType where G.Element == Byte>(inout generator: G, cou
 /// - parameter generator: The input generator to unpack.
 ///
 /// - returns: A `MessagePackValue`.
-public func unpack<G: GeneratorType where G.Element == Byte>(inout generator: G, compatibility: Bool = false) throws -> MessagePackValue {
+public func unpack<G: IteratorProtocol>(_ generator: inout G, compatibility: Bool = false) throws -> MessagePackValue where G.Element == Byte {
     if let value = generator.next() {
         switch value {
 
         // positive fixint
         case 0x00...0x7f:
-            return .UInt(numericCast(value))
+            return .uInt(numericCast(value))
 
         // fixmap
         case 0x80...0x8f:
             let count = Int(value - 0x80)
             let dict = try unpackMap(&generator, count: count, compatibility: compatibility)
-            return .Map(dict)
+            return .map(dict)
 
         // fixarray
         case 0x90...0x9f:
             let count = Int(value - 0x90)
             let array = try unpackArray(&generator, count: count, compatibility: compatibility)
-            return .Array(array)
+            return .array(array)
 
         // fixstr
         case 0xa0...0xbf:
             let length = Int(value - 0xa0)
             if compatibility {
                 let data = try unpackData(&generator, length: length)
-                return .Binary(data)
+                return .binary(data)
             } else {
                 let string = try unpackString(&generator, length: length)
-                return .String(string)
+                return .string(string)
             }
 
 
         // nil
         case 0xc0:
-            return .Nil
+            return .nil
 
         // false
         case 0xc2:
-            return .Bool(false)
+            return .bool(false)
 
         // true
         case 0xc3:
-            return .Bool(true)
+            return .bool(true)
 
         // bin 8, 16, 32
         case 0xc4...0xc6:
             let size = 1 << numericCast(value - 0xc4)
             let length = try unpackInteger(&generator, size: size)
             let subdata = try unpackData(&generator, length: numericCast(length))
-            return .Binary(subdata)
+            return .binary(subdata)
 
         // ext 8, 16, 32
         case 0xc7...0xc9:
@@ -167,55 +167,55 @@ public func unpack<G: GeneratorType where G.Element == Byte>(inout generator: G,
             if let typeByte = generator.next() {
                 let type = Int8(bitPattern: typeByte)
                 let data = try unpackData(&generator, length: numericCast(length))
-                return .Extended(type, data)
+                return .extended(type, data)
             } else {
-                throw MessagePackError.InsufficientData
+                throw MessagePackError.insufficientData
             }
 
         // float 32
         case 0xca:
             let bytes = try unpackInteger(&generator, size: 4)
-            let float = unsafeBitCast(UInt32(truncatingBitPattern: bytes), Float.self)
-            return .Float(float)
+            let float = unsafeBitCast(UInt32(truncatingBitPattern: bytes), to: Float.self)
+            return .float(float)
 
         // float 64
         case 0xcb:
             let bytes = try unpackInteger(&generator, size: 8)
-            let double = unsafeBitCast(bytes, Double.self)
-            return .Double(double)
+            let double = unsafeBitCast(bytes, to: Double.self)
+            return .double(double)
 
         // uint 8, 16, 32, 64
         case 0xcc...0xcf:
             let size = 1 << (numericCast(value) - 0xcc)
             let integer = try unpackInteger(&generator, size: size)
-            return .UInt(integer)
+            return .uInt(integer)
 
         // int 8
         case 0xd0:
             if let byte = generator.next() {
                 let integer = Int8(bitPattern: byte)
-                return .Int(numericCast(integer))
+                return .int(numericCast(integer))
             } else {
-                throw MessagePackError.InsufficientData
+                throw MessagePackError.insufficientData
             }
 
         // int 16
         case 0xd1:
             let bytes = try unpackInteger(&generator, size: 2)
             let integer = Int16(bitPattern: UInt16(truncatingBitPattern: bytes))
-            return .Int(numericCast(integer))
+            return .int(numericCast(integer))
 
         // int 32
         case 0xd2:
             let bytes = try unpackInteger(&generator, size: 4)
             let integer = Int32(bitPattern: UInt32(truncatingBitPattern: bytes))
-            return .Int(numericCast(integer))
+            return .int(numericCast(integer))
 
         // int 64
         case 0xd3:
             let bytes = try unpackInteger(&generator, size: 8)
             let integer = Int64(bitPattern: bytes)
-            return .Int(integer)
+            return .int(integer)
 
         // fixent 1, 2, 4, 8, 16
         case 0xd4...0xd8:
@@ -223,9 +223,9 @@ public func unpack<G: GeneratorType where G.Element == Byte>(inout generator: G,
             if let typeByte = generator.next() {
                 let type = Int8(bitPattern: typeByte)
                 let bytes = try unpackData(&generator, length: length)
-                return .Extended(type, bytes)
+                return .extended(type, bytes)
             } else {
-                throw MessagePackError.InsufficientData
+                throw MessagePackError.insufficientData
             }
 
         // str 8, 16, 32
@@ -234,10 +234,10 @@ public func unpack<G: GeneratorType where G.Element == Byte>(inout generator: G,
             let length = try unpackInteger(&generator, size: lengthSize)
             if compatibility {
                 let data = try unpackData(&generator, length: numericCast(length))
-                return .Binary(data)
+                return .binary(data)
             } else {
                 let string = try unpackString(&generator, length: numericCast(length))
-                return .String(string)
+                return .string(string)
             }
 
         // array 16, 32
@@ -245,28 +245,28 @@ public func unpack<G: GeneratorType where G.Element == Byte>(inout generator: G,
             let countSize = 1 << Int(value - 0xdb)
             let count = try unpackInteger(&generator, size: countSize)
             let array = try unpackArray(&generator, count: numericCast(count), compatibility: compatibility)
-            return .Array(array)
+            return .array(array)
 
         // map 16, 32
         case 0xde...0xdf:
             let countSize = 1 << Int(value - 0xdd)
             let count = try unpackInteger(&generator, size: countSize)
             let dict = try unpackMap(&generator, count: numericCast(count), compatibility: compatibility)
-            return .Map(dict)
+            return .map(dict)
 
         // negative fixint
         case 0xe0..<0xff:
-            return .Int(numericCast(value) - 0x100)
+            return .int(numericCast(value) - 0x100)
 
         // negative fixint (workaround for rdar://19779978)
         case 0xff:
-            return .Int(numericCast(value) - 0x100)
+            return .int(numericCast(value) - 0x100)
 
         default:
-            throw MessagePackError.InvalidData
+            throw MessagePackError.invalidData
         }
     } else {
-        throw MessagePackError.InsufficientData
+        throw MessagePackError.insufficientData
     }
 }
 
@@ -275,8 +275,8 @@ public func unpack<G: GeneratorType where G.Element == Byte>(inout generator: G,
 /// - parameter data: The data to unpack.
 ///
 /// - returns: The contained `MessagePackValue`.
-public func unpack(data: NSData, compatibility: Bool = false) throws -> MessagePackValue {
-    var generator = NSDataGenerator(data: data)
+public func unpack(_ data: Foundation.Data, compatibility: Bool = false) throws -> MessagePackValue {
+    var generator = NSDataGenerator(data: data as NSData)
     return try unpack(&generator, compatibility: compatibility)
 }
 
@@ -285,7 +285,7 @@ public func unpack(data: NSData, compatibility: Bool = false) throws -> MessageP
 /// - parameter data: The data to unpack.
 ///
 /// - returns: The contained `MessagePackValue`.
-public func unpack(data: dispatch_data_t, compatibility: Bool = false) throws -> MessagePackValue {
+public func unpack(_ data: DispatchData, compatibility: Bool = false) throws -> MessagePackValue {
     var generator = DispatchDataGenerator(data: data)
     return try unpack(&generator, compatibility: compatibility)
 }
@@ -295,7 +295,7 @@ public func unpack(data: dispatch_data_t, compatibility: Bool = false) throws ->
 /// - parameter data: The data to unpack.
 ///
 /// - returns: The contained `MessagePackValue`.
-public func unpack<S: SequenceType where S.Generator.Element == Byte>(data: S, compatibility: Bool = false) throws -> MessagePackValue {
-    var generator = data.generate()
+public func unpack<S: Sequence>(_ data: S, compatibility: Bool = false) throws -> MessagePackValue where S.Iterator.Element == Byte {
+    var generator = data.makeIterator()
     return try unpack(&generator, compatibility: compatibility)
 }

--- a/MessagePackTests/ArrayTests.swift
+++ b/MessagePackTests/ArrayTests.swift
@@ -4,49 +4,49 @@ import XCTest
 class ArrayTests: XCTestCase {
     func testLiteralConversion() {
         let implicitValue: MessagePackValue = [0, 1, 2, 3, 4]
-        let payload: [MessagePackValue] = [.UInt(0), .UInt(1), .UInt(2), .UInt(3), .UInt(4)]
-        XCTAssertEqual(implicitValue, MessagePackValue.Array(payload))
+        let payload: [MessagePackValue] = [.uInt(0), .uInt(1), .uInt(2), .uInt(3), .uInt(4)]
+        XCTAssertEqual(implicitValue, MessagePackValue.array(payload))
     }
 
     func testPackFixarray() {
-        let value: [MessagePackValue] = [.UInt(0), .UInt(1), .UInt(2), .UInt(3), .UInt(4)]
-        let packed: Data = [0x95, 0x00, 0x01, 0x02, 0x03, 0x04]
-        XCTAssertEqual(pack(.Array(value)), packed)
+        let value: [MessagePackValue] = [.uInt(0), .uInt(1), .uInt(2), .uInt(3), .uInt(4)]
+        let packed: MessagePack.Data = [0x95, 0x00, 0x01, 0x02, 0x03, 0x04]
+        XCTAssertEqual(pack(.array(value)), packed)
     }
 
     func testUnpackFixarray() {
-        let packed: Data = [0x95, 0x00, 0x01, 0x02, 0x03, 0x04]
-        let value: [MessagePackValue] = [.UInt(0), .UInt(1), .UInt(2), .UInt(3), .UInt(4)]
+        let packed: MessagePack.Data = [0x95, 0x00, 0x01, 0x02, 0x03, 0x04]
+        let value: [MessagePackValue] = [.uInt(0), .uInt(1), .uInt(2), .uInt(3), .uInt(4)]
 
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Array(value))
+        XCTAssertEqual(unpacked, MessagePackValue.array(value))
     }
 
     func testPackArray16() {
-        let value = [MessagePackValue](count: 16, repeatedValue: nil)
-        let packed = [0xdc, 0x00, 0x10] + Data(count: 16, repeatedValue: 0xc0)
-        XCTAssertEqual(pack(.Array(value)), packed)
+        let value = [MessagePackValue](repeating: nil, count: 16)
+        let packed = [0xdc, 0x00, 0x10] + MessagePack.Data(repeating: 0xc0, count: 16)
+        XCTAssertEqual(pack(.array(value)), packed)
     }
 
     func testUnpackArray16() {
-        let packed = [0xdc, 0x00, 0x10] + Data(count: 16, repeatedValue: 0xc0)
-        let value = [MessagePackValue](count: 16, repeatedValue: nil)
+        let packed = [0xdc, 0x00, 0x10] + MessagePack.Data(repeating: 0xc0, count: 16)
+        let value = [MessagePackValue](repeating: nil, count: 16)
 
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Array(value))
+        XCTAssertEqual(unpacked, MessagePackValue.array(value))
     }
 
     func testPackArray32() {
-        let value = [MessagePackValue](count: 0x1_0000, repeatedValue: nil)
-        let packed = [0xdd, 0x00, 0x01, 0x00, 0x00] + Data(count: 0x1_0000, repeatedValue: 0xc0)
-        XCTAssertEqual(pack(.Array(value)), packed)
+        let value = [MessagePackValue](repeating: nil, count: 0x1_0000)
+        let packed = [0xdd, 0x00, 0x01, 0x00, 0x00] + MessagePack.Data(repeating: 0xc0, count: 0x1_0000)
+        XCTAssertEqual(pack(.array(value)), packed)
     }
 
     func testUnpackArray32() {
-        let packed = [0xdd, 0x00, 0x01, 0x00, 0x00] + Data(count: 0x1_0000, repeatedValue: 0xc0)
-        let value = [MessagePackValue](count: 0x1_0000, repeatedValue: nil)
+        let packed = [0xdd, 0x00, 0x01, 0x00, 0x00] + MessagePack.Data(repeating: 0xc0, count: 0x1_0000)
+        let value = [MessagePackValue](repeating: nil, count: 0x1_0000)
 
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Array(value))
+        XCTAssertEqual(unpacked, MessagePackValue.array(value))
     }
 }

--- a/MessagePackTests/BinaryTests.swift
+++ b/MessagePackTests/BinaryTests.swift
@@ -2,62 +2,62 @@
 import XCTest
 
 class BinaryTests: XCTestCase {
-    let payload: Data = [0x00, 0x01, 0x02, 0x03, 0x04]
-    let packed: Data = [0xc4, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04]
+    let payload: MessagePack.Data = [0x00, 0x01, 0x02, 0x03, 0x04]
+    let packed: MessagePack.Data = [0xc4, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04]
 
     func testPack() {
-        XCTAssertEqual(pack(.Binary(payload)), packed)
+        XCTAssertEqual(pack(.binary(payload)), packed)
     }
 
     func testUnpack() {
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Binary(payload))
+        XCTAssertEqual(unpacked, MessagePackValue.binary(payload))
     }
 
     func testPackBin16() {
-        let value = Data(count: 0xff, repeatedValue: 0x00)
+        let value = MessagePack.Data(repeating: 0x00, count: 0xff)
         let expectedPacked = [0xc4, 0xff] + value
-        XCTAssertEqual(pack(.Binary(value)), expectedPacked)
+        XCTAssertEqual(pack(.binary(value)), expectedPacked)
     }
 
     func testUnpackBin16() {
-        let data = [0xc4, 0xff] + Data(count: 0xff, repeatedValue: 0x00)
-        let value = Data(count: 0xff, repeatedValue: 0x00)
+        let data = [0xc4, 0xff] + MessagePack.Data(repeating: 0x00, count: 0xff)
+        let value = MessagePack.Data(repeating: 0x00, count: 0xff)
 
         let unpacked = try? unpack(data)
-        XCTAssertEqual(unpacked, MessagePackValue.Binary(value))
+        XCTAssertEqual(unpacked, MessagePackValue.binary(value))
     }
 
     func testPackBin32() {
-        let value = Data(count: 0x100, repeatedValue: 0x00)
+        let value = MessagePack.Data(repeating: 0x00, count: 0x100)
         let expectedPacked = [0xc5, 0x01, 0x00] + value
-        XCTAssertEqual(pack(.Binary(value)), expectedPacked)
+        XCTAssertEqual(pack(.binary(value)), expectedPacked)
     }
 
     func testUnpackBin32() {
-        let data =  [0xc5, 0x01, 0x00] + Data(count: 0x100, repeatedValue: 0x00)
-        let value = Data(count: 0x100, repeatedValue: 0x00)
+        let data =  [0xc5, 0x01, 0x00] + MessagePack.Data(repeating: 0x00, count: 0x100)
+        let value = MessagePack.Data(repeating: 0x00, count: 0x100)
 
         let unpacked = try? unpack(data)
-        XCTAssertEqual(unpacked, MessagePackValue.Binary(value))
+        XCTAssertEqual(unpacked, MessagePackValue.binary(value))
     }
 
     func testPackBin64() {
-        let value = Data(count: 0x1_0000, repeatedValue: 0x00)
+        let value = MessagePack.Data(repeating: 0x00, count: 0x1_0000)
         let expectedPacked = [0xc6, 0x00, 0x01, 0x00, 0x00] + value
-        XCTAssertEqual(pack(.Binary(value)), expectedPacked)
+        XCTAssertEqual(pack(.binary(value)), expectedPacked)
     }
 
     func testUnpackBin64() {
-        let data = [0xc6, 0x00, 0x01, 0x00, 0x00] + Data(count: 0x1_0000, repeatedValue: 0x00)
-        let value = Data(count: 0x1_0000, repeatedValue: 0x00)
+        let data = [0xc6, 0x00, 0x01, 0x00, 0x00] + MessagePack.Data(repeating: 0x00, count: 0x1_0000)
+        let value = MessagePack.Data(repeating: 0x00, count: 0x1_0000)
 
         let unpacked = try? unpack(data)
-        XCTAssertEqual(unpacked, MessagePackValue.Binary(value))
+        XCTAssertEqual(unpacked, MessagePackValue.binary(value))
     }
 
     func testUnpackInsufficientData() {
-        let dataArray: [Data] = [
+        let dataArray: [MessagePack.Data] = [
             // only type byte
             [0xc4], [0xc5], [0xc6],
 
@@ -68,43 +68,43 @@ class BinaryTests: XCTestCase {
         ]
         for data in dataArray {
             do {
-                try unpack(data)
+                let _ = try unpack(data)
                 XCTFail("Expected unpack to throw")
             } catch {
-                XCTAssertEqual(error as? MessagePackError, .InsufficientData)
+                XCTAssertEqual(error as? MessagePackError, .insufficientData)
             }
         }
     }
 
     func testUnpackFixstrWithCompatibility() {
-        let data: Data = [0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]
-        let packed: Data = [0xad] + data
+        let data: MessagePack.Data = [0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]
+        let packed: MessagePack.Data = [0xad] + data
 
         let unpacked = try? unpack(packed, compatibility: true)
-        XCTAssertEqual(unpacked, MessagePackValue.Binary(data))
+        XCTAssertEqual(unpacked, MessagePackValue.binary(data))
     }
 
     func testUnpackStr8WithCompatibility() {
-        let data = Data(count: 0x20, repeatedValue: 0x00)
+        let data = MessagePack.Data(repeating: 0x00, count: 0x20)
         let packed = [0xd9, 0x20] + data
 
         let unpacked = try? unpack(packed, compatibility: true)
-        XCTAssertEqual(unpacked, MessagePackValue.Binary(data))
+        XCTAssertEqual(unpacked, MessagePackValue.binary(data))
     }
 
     func testUnpackStr16WithCompatibility() {
-        let data = Data(count: 0x1000, repeatedValue: 0x00)
+        let data = MessagePack.Data(repeating: 0x00, count: 0x1000)
         let packed = [0xda, 0x10, 0x00] + data
 
         let unpacked = try? unpack(packed, compatibility: true)
-        XCTAssertEqual(unpacked, MessagePackValue.Binary(data))
+        XCTAssertEqual(unpacked, MessagePackValue.binary(data))
     }
 
     func testUnpackStr32WithCompatibility() {
-        let data = Data(count: 0x10000, repeatedValue: 0x00)
+        let data = MessagePack.Data(repeating: 0x00, count: 0x10000)
         let packed = [0xdb, 0x00, 0x01, 0x00, 0x00] + data
 
         let unpacked = try? unpack(packed, compatibility: true)
-        XCTAssertEqual(unpacked, MessagePackValue.Binary(data))
+        XCTAssertEqual(unpacked, MessagePackValue.binary(data))
     }
 }

--- a/MessagePackTests/ConvenienceInitializersTests.swift
+++ b/MessagePackTests/ConvenienceInitializersTests.swift
@@ -3,57 +3,57 @@ import XCTest
 
 class ConvenienceInitializersTests: XCTestCase {
     func testNil() {
-        XCTAssertEqual(MessagePackValue(), MessagePackValue.Nil)
+        XCTAssertEqual(MessagePackValue(), MessagePackValue.nil)
     }
 
     func testBool() {
-        XCTAssertEqual(MessagePackValue(true), MessagePackValue.Bool(true))
-        XCTAssertEqual(MessagePackValue(false), MessagePackValue.Bool(false))
+        XCTAssertEqual(MessagePackValue(true), MessagePackValue.bool(true))
+        XCTAssertEqual(MessagePackValue(false), MessagePackValue.bool(false))
     }
 
     func testUInt() {
-        XCTAssertEqual(MessagePackValue(0 as UInt), MessagePackValue.UInt(0))
-        XCTAssertEqual(MessagePackValue(0xff as UInt8), MessagePackValue.UInt(0xff))
-        XCTAssertEqual(MessagePackValue(0xffff as UInt16), MessagePackValue.UInt(0xffff))
-        XCTAssertEqual(MessagePackValue(0xffff_ffff as UInt32), MessagePackValue.UInt(0xffff_ffff))
-        XCTAssertEqual(MessagePackValue(0xffff_ffff_ffff_ffff as UInt64), MessagePackValue.UInt(0xffff_ffff_ffff_ffff))
+        XCTAssertEqual(MessagePackValue(0 as UInt), MessagePackValue.uInt(0))
+        XCTAssertEqual(MessagePackValue(0xff as UInt8), MessagePackValue.uInt(0xff))
+        XCTAssertEqual(MessagePackValue(0xffff as UInt16), MessagePackValue.uInt(0xffff))
+        XCTAssertEqual(MessagePackValue(0xffff_ffff as UInt32), MessagePackValue.uInt(0xffff_ffff))
+        XCTAssertEqual(MessagePackValue(0xffff_ffff_ffff_ffff as UInt64), MessagePackValue.uInt(0xffff_ffff_ffff_ffff))
     }
 
     func testInt() {
-        XCTAssertEqual(MessagePackValue(-1 as Int), MessagePackValue.Int(-1))
-        XCTAssertEqual(MessagePackValue(-0x7f as Int8), MessagePackValue.Int(-0x7f))
-        XCTAssertEqual(MessagePackValue(-0x7fff as Int16), MessagePackValue.Int(-0x7fff))
-        XCTAssertEqual(MessagePackValue(-0x7fff_ffff as Int32), MessagePackValue.Int(-0x7fff_ffff))
-        XCTAssertEqual(MessagePackValue(-0x7fff_ffff_ffff_ffff as Int64), MessagePackValue.Int(-0x7fff_ffff_ffff_ffff))
+        XCTAssertEqual(MessagePackValue(-1 as Int), MessagePackValue.int(-1))
+        XCTAssertEqual(MessagePackValue(-0x7f as Int8), MessagePackValue.int(-0x7f))
+        XCTAssertEqual(MessagePackValue(-0x7fff as Int16), MessagePackValue.int(-0x7fff))
+        XCTAssertEqual(MessagePackValue(-0x7fff_ffff as Int32), MessagePackValue.int(-0x7fff_ffff))
+        XCTAssertEqual(MessagePackValue(-0x7fff_ffff_ffff_ffff as Int64), MessagePackValue.int(-0x7fff_ffff_ffff_ffff))
     }
 
     func testFloat() {
-        XCTAssertEqual(MessagePackValue(0 as Float), MessagePackValue.Float(0))
-        XCTAssertEqual(MessagePackValue(1.618 as Float), MessagePackValue.Float(1.618))
-        XCTAssertEqual(MessagePackValue(3.14 as Float), MessagePackValue.Float(3.14))
+        XCTAssertEqual(MessagePackValue(0 as Float), MessagePackValue.float(0))
+        XCTAssertEqual(MessagePackValue(1.618 as Float), MessagePackValue.float(1.618))
+        XCTAssertEqual(MessagePackValue(3.14 as Float), MessagePackValue.float(3.14))
     }
 
     func testDouble() {
-        XCTAssertEqual(MessagePackValue(0 as Double), MessagePackValue.Double(0))
-        XCTAssertEqual(MessagePackValue(1.618 as Double), MessagePackValue.Double(1.618))
-        XCTAssertEqual(MessagePackValue(3.14 as Double), MessagePackValue.Double(3.14))
+        XCTAssertEqual(MessagePackValue(0 as Double), MessagePackValue.double(0))
+        XCTAssertEqual(MessagePackValue(1.618 as Double), MessagePackValue.double(1.618))
+        XCTAssertEqual(MessagePackValue(3.14 as Double), MessagePackValue.double(3.14))
     }
 
     func testString() {
-        XCTAssertEqual(MessagePackValue("Hello, world!"), MessagePackValue.String("Hello, world!"))
+        XCTAssertEqual(MessagePackValue("Hello, world!"), MessagePackValue.string("Hello, world!"))
     }
 
 
     func testArray() {
-        XCTAssertEqual(MessagePackValue([.UInt(0), .UInt(1), .UInt(2), .UInt(3), .UInt(4)]), MessagePackValue.Array([.UInt(0), .UInt(1), .UInt(2), .UInt(3), .UInt(4)]))
+        XCTAssertEqual(MessagePackValue([.uInt(0), .uInt(1), .uInt(2), .uInt(3), .uInt(4)]), MessagePackValue.array([.uInt(0), .uInt(1), .uInt(2), .uInt(3), .uInt(4)]))
     }
 
     func testMap() {
-        XCTAssertEqual(MessagePackValue([.String("c"): .String("cookie")]), MessagePackValue.Map([.String("c"): .String("cookie")]))
+        XCTAssertEqual(MessagePackValue([.string("c"): .string("cookie")]), MessagePackValue.map([.string("c"): .string("cookie")]))
     }
 
     func testBinary() {
-        let data: Data = [0x00, 0x01, 0x02, 0x03, 0x04]
-        XCTAssertEqual(MessagePackValue(data), MessagePackValue.Binary([0x00, 0x01, 0x02, 0x03, 0x04]))
+        let data: MessagePack.Data = [0x00, 0x01, 0x02, 0x03, 0x04]
+        XCTAssertEqual(MessagePackValue(data), MessagePackValue.binary([0x00, 0x01, 0x02, 0x03, 0x04]))
     }
 }

--- a/MessagePackTests/ConveniencePropertiesTests.swift
+++ b/MessagePackTests/ConveniencePropertiesTests.swift
@@ -3,103 +3,103 @@ import XCTest
 
 class ConveniencePropertiesTests: XCTestCase {
     func testCount() {
-        XCTAssert(MessagePackValue.Array([0]).count == 1)
-        XCTAssert(MessagePackValue.Map(["c": "cookie"]).count == 1)
-        XCTAssert(MessagePackValue.Nil.count == nil)
+        XCTAssert(MessagePackValue.array([0]).count == 1)
+        XCTAssert(MessagePackValue.map(["c": "cookie"]).count == 1)
+        XCTAssert(MessagePackValue.nil.count == nil)
     }
 
     func testIndexedSubscript() {
-        XCTAssert(MessagePackValue.Array([0])[0] == .UInt(0))
-        XCTAssert(MessagePackValue.Array([0])[1] == nil)
-        XCTAssert(MessagePackValue.Nil[0] == nil)
+        XCTAssert(MessagePackValue.array([0])[0] == .uInt(0))
+        XCTAssert(MessagePackValue.array([0])[1] == nil)
+        XCTAssert(MessagePackValue.nil[0] == nil)
     }
 
     func testKeyedSubscript() {
-        XCTAssert(MessagePackValue.Map(["c": "cookie"])["c"] == "cookie")
-        XCTAssert(MessagePackValue.Nil["c"] == nil)
+        XCTAssert(MessagePackValue.map(["c": "cookie"])["c"] == "cookie")
+        XCTAssert(MessagePackValue.nil["c"] == nil)
     }
 
     func testIsNil() {
-        XCTAssertTrue(MessagePackValue.Nil.isNil)
-        XCTAssertFalse(MessagePackValue.Bool(true).isNil)
+        XCTAssertTrue(MessagePackValue.nil.isNil)
+        XCTAssertFalse(MessagePackValue.bool(true).isNil)
     }
 
     func testIntegerValue() {
-        XCTAssert(MessagePackValue.Int(-1).integerValue == -1)
-        XCTAssert(MessagePackValue.UInt(1).integerValue == 1)
-        XCTAssert(MessagePackValue.Nil.integerValue == nil)
+        XCTAssert(MessagePackValue.int(-1).integerValue == -1)
+        XCTAssert(MessagePackValue.uInt(1).integerValue == 1)
+        XCTAssert(MessagePackValue.nil.integerValue == nil)
     }
 
     func testUnsignedIntegerValue() {
-        XCTAssert(MessagePackValue.Int(-1).unsignedIntegerValue == nil)
-        XCTAssert(MessagePackValue.Int(1).unsignedIntegerValue == 1)
-        XCTAssert(MessagePackValue.UInt(1).unsignedIntegerValue == 1)
-        XCTAssert(MessagePackValue.Nil.unsignedIntegerValue == nil)
+        XCTAssert(MessagePackValue.int(-1).unsignedIntegerValue == nil)
+        XCTAssert(MessagePackValue.int(1).unsignedIntegerValue == 1)
+        XCTAssert(MessagePackValue.uInt(1).unsignedIntegerValue == 1)
+        XCTAssert(MessagePackValue.nil.unsignedIntegerValue == nil)
     }
 
     func testArrayValue() {
-        let arrayValue = MessagePackValue.Array([0]).arrayValue
+        let arrayValue = MessagePackValue.array([0]).arrayValue
         XCTAssertNotNil(arrayValue)
         XCTAssertEqual(arrayValue!, [0])
-        XCTAssert(MessagePackValue.Nil.arrayValue == nil)
+        XCTAssert(MessagePackValue.nil.arrayValue == nil)
     }
 
     func testBoolValue() {
-        XCTAssert(MessagePackValue.Bool(true).boolValue == true)
-        XCTAssert(MessagePackValue.Bool(false).boolValue == false)
-        XCTAssert(MessagePackValue.Nil.boolValue == nil)
+        XCTAssert(MessagePackValue.bool(true).boolValue == true)
+        XCTAssert(MessagePackValue.bool(false).boolValue == false)
+        XCTAssert(MessagePackValue.nil.boolValue == nil)
     }
 
     func testFloatValue() {
-        XCTAssert(MessagePackValue.Nil.floatValue == nil)
+        XCTAssert(MessagePackValue.nil.floatValue == nil)
 
-        var floatValue = MessagePackValue.Float(3.14).floatValue
+        var floatValue = MessagePackValue.float(3.14).floatValue
         XCTAssertNotNil(floatValue)
         XCTAssertEqualWithAccuracy(floatValue!, 3.14, accuracy: 0.0001)
 
-        floatValue = MessagePackValue.Double(3.14).floatValue
+        floatValue = MessagePackValue.double(3.14).floatValue
         XCTAssertNotNil(floatValue)
         XCTAssertEqualWithAccuracy(floatValue!, 3.14, accuracy: 0.0001)
     }
 
     func testDoubleValue() {
-        XCTAssert(MessagePackValue.Nil.doubleValue == nil)
+        XCTAssert(MessagePackValue.nil.doubleValue == nil)
 
-        var doubleValue = MessagePackValue.Float(3.14).doubleValue
+        var doubleValue = MessagePackValue.float(3.14).doubleValue
         XCTAssertNotNil(doubleValue)
         XCTAssertEqualWithAccuracy(doubleValue!, 3.14, accuracy: 0.0001)
 
-        doubleValue = MessagePackValue.Double(3.14).doubleValue
+        doubleValue = MessagePackValue.double(3.14).doubleValue
         XCTAssertNotNil(doubleValue)
         XCTAssertEqualWithAccuracy(doubleValue!, 3.14, accuracy: 0.0001)
     }
 
     func testStringValue() {
-        XCTAssert(MessagePackValue.String("Hello, world!").stringValue == "Hello, world!")
-        XCTAssert(MessagePackValue.Nil.stringValue == nil)
+        XCTAssert(MessagePackValue.string("Hello, world!").stringValue == "Hello, world!")
+        XCTAssert(MessagePackValue.nil.stringValue == nil)
     }
 
     func testStringValueWithCompatibility() {
-        let stringValue = MessagePackValue.Binary([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]).stringValue
+        let stringValue = MessagePackValue.binary([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]).stringValue
         XCTAssertEqual(stringValue, "Hello, world!")
     }
 
     func testDataValue() {
-        XCTAssert(MessagePackValue.Nil.dataValue == nil)
+        XCTAssert(MessagePackValue.nil.dataValue == nil)
 
-        var dataValue = MessagePackValue.Binary([0x00, 0x01, 0x02, 0x03, 0x04]).dataValue
+        var dataValue = MessagePackValue.binary([0x00, 0x01, 0x02, 0x03, 0x04]).dataValue
         XCTAssertNotNil(dataValue)
         XCTAssertEqual(dataValue!, [0x00, 0x01, 0x02, 0x03, 0x04])
 
-        dataValue = MessagePackValue.Extended(4, [0x00, 0x01, 0x02, 0x03, 0x04]).dataValue
+        dataValue = MessagePackValue.extended(4, [0x00, 0x01, 0x02, 0x03, 0x04]).dataValue
         XCTAssertNotNil(dataValue)
         XCTAssertEqual(dataValue!, [0x00, 0x01, 0x02, 0x03, 0x04])
     }
 
     func testExtendedValue() {
-        XCTAssert(MessagePackValue.Nil.extendedValue == nil)
+        XCTAssert(MessagePackValue.nil.extendedValue == nil)
 
-        let extended = MessagePackValue.Extended(4, [0x00, 0x01, 0x02, 0x03, 0x04])
+        let extended = MessagePackValue.extended(4, [0x00, 0x01, 0x02, 0x03, 0x04])
         let tuple = extended.extendedValue
         XCTAssertNotNil(tuple)
 
@@ -109,18 +109,18 @@ class ConveniencePropertiesTests: XCTestCase {
     }
 
     func testExtendedType() {
-        XCTAssert(MessagePackValue.Nil.extendedType == nil)
+        XCTAssert(MessagePackValue.nil.extendedType == nil)
 
-        let extended = MessagePackValue.Extended(4, [0x00, 0x01, 0x02, 0x03, 0x04])
+        let extended = MessagePackValue.extended(4, [0x00, 0x01, 0x02, 0x03, 0x04])
         let type = extended.extendedType
         XCTAssertNotNil(type)
         XCTAssertEqual(type!, 4)
     }
 
     func testMapValue() {
-        let dictionaryValue = MessagePackValue.Map(["c": "cookie"]).dictionaryValue
+        let dictionaryValue = MessagePackValue.map(["c": "cookie"]).dictionaryValue
         XCTAssertNotNil(dictionaryValue)
         XCTAssertEqual(dictionaryValue!, ["c": "cookie"])
-        XCTAssert(MessagePackValue.Nil.dictionaryValue == nil)
+        XCTAssert(MessagePackValue.nil.dictionaryValue == nil)
     }
 }

--- a/MessagePackTests/DescriptionTests.swift
+++ b/MessagePackTests/DescriptionTests.swift
@@ -3,51 +3,51 @@ import XCTest
 
 class DescriptionTests: XCTestCase {
     func testNilDescription() {
-        XCTAssertEqual(MessagePackValue.Nil.description, "Nil")
+        XCTAssertEqual(MessagePackValue.nil.description, "Nil")
     }
 
     func testBoolDescription() {
-        XCTAssertEqual(MessagePackValue.Bool(true).description, "Bool(true)")
-        XCTAssertEqual(MessagePackValue.Bool(false).description, "Bool(false)")
+        XCTAssertEqual(MessagePackValue.bool(true).description, "Bool(true)")
+        XCTAssertEqual(MessagePackValue.bool(false).description, "Bool(false)")
     }
 
     func testIntDescription() {
-        XCTAssertEqual(MessagePackValue.Int(-1).description, "Int(-1)")
-        XCTAssertEqual(MessagePackValue.Int(0).description, "Int(0)")
-        XCTAssertEqual(MessagePackValue.Int(1).description, "Int(1)")
+        XCTAssertEqual(MessagePackValue.int(-1).description, "Int(-1)")
+        XCTAssertEqual(MessagePackValue.int(0).description, "Int(0)")
+        XCTAssertEqual(MessagePackValue.int(1).description, "Int(1)")
     }
 
     func testUIntDescription() {
-        XCTAssertEqual(MessagePackValue.UInt(0).description, "UInt(0)")
-        XCTAssertEqual(MessagePackValue.UInt(1).description, "UInt(1)")
-        XCTAssertEqual(MessagePackValue.UInt(2).description, "UInt(2)")
+        XCTAssertEqual(MessagePackValue.uInt(0).description, "UInt(0)")
+        XCTAssertEqual(MessagePackValue.uInt(1).description, "UInt(1)")
+        XCTAssertEqual(MessagePackValue.uInt(2).description, "UInt(2)")
     }
 
     func testFloatDescription() {
-        XCTAssertEqual(MessagePackValue.Float(0.0).description, "Float(0.0)")
-        XCTAssertEqual(MessagePackValue.Float(1.618).description, "Float(1.618)")
-        XCTAssertEqual(MessagePackValue.Float(3.14).description, "Float(3.14)")
+        XCTAssertEqual(MessagePackValue.float(0.0).description, "Float(0.0)")
+        XCTAssertEqual(MessagePackValue.float(1.618).description, "Float(1.618)")
+        XCTAssertEqual(MessagePackValue.float(3.14).description, "Float(3.14)")
     }
 
     func testDoubleDescription() {
-        XCTAssertEqual(MessagePackValue.Double(0.0).description, "Double(0.0)")
-        XCTAssertEqual(MessagePackValue.Double(1.618).description, "Double(1.618)")
-        XCTAssertEqual(MessagePackValue.Double(3.14).description, "Double(3.14)")
+        XCTAssertEqual(MessagePackValue.double(0.0).description, "Double(0.0)")
+        XCTAssertEqual(MessagePackValue.double(1.618).description, "Double(1.618)")
+        XCTAssertEqual(MessagePackValue.double(3.14).description, "Double(3.14)")
     }
 
     func testStringDescription() {
-        XCTAssertEqual(MessagePackValue.String("").description, "String()".description)
-        XCTAssertEqual(MessagePackValue.String("MessagePack").description, "String(MessagePack)".description)
+        XCTAssertEqual(MessagePackValue.string("").description, "String()".description)
+        XCTAssertEqual(MessagePackValue.string("MessagePack").description, "String(MessagePack)".description)
     }
 
     func testBinaryDescription() {
-        XCTAssertEqual(MessagePackValue.Binary([]).description, "Data([])")
-        XCTAssertEqual(MessagePackValue.Binary([0x00, 0x01, 0x02, 0x03, 0x04]).description, "Data([0x00, 0x01, 0x02, 0x03, 0x04])")
+        XCTAssertEqual(MessagePackValue.binary([]).description, "Data([])")
+        XCTAssertEqual(MessagePackValue.binary([0x00, 0x01, 0x02, 0x03, 0x04]).description, "Data([0x00, 0x01, 0x02, 0x03, 0x04])")
     }
 
     func testArrayDescription() {
         let values: [MessagePackValue] = [1, true, ""]
-        XCTAssertEqual(MessagePackValue.Array(values).description, "Array([Int(1), Bool(true), String()])")
+        XCTAssertEqual(MessagePackValue.array(values).description, "Array([Int(1), Bool(true), String()])")
     }
 
     func testMapDescription() {
@@ -72,12 +72,12 @@ class DescriptionTests: XCTestCase {
             [2, 1, 0],
         ]
 
-        let description = MessagePackValue.Map(values).description
+        let description = MessagePackValue.map(values).description
 
         var isValid = false
         for indices in indexPermutations {
-            let permutation = PermutationGenerator(elements: components, indices: indices)
-            let innerDescription = permutation.joinWithSeparator(", ")
+            let permutation = indices.map { (i) in components[i] }
+            let innerDescription = permutation.joined(separator: ", ")
             if description == "Map([\(innerDescription)])" {
                 isValid = true
                 break
@@ -88,7 +88,7 @@ class DescriptionTests: XCTestCase {
     }
 
     func testExtendedDescription() {
-        XCTAssertEqual(MessagePackValue.Extended(5, []).description, "Extended(5, [])")
-        XCTAssertEqual(MessagePackValue.Extended(5, [0x00, 0x10, 0x20, 0x30, 0x40]).description, "Extended(5, [0x00, 0x10, 0x20, 0x30, 0x40])")
+        XCTAssertEqual(MessagePackValue.extended(5, []).description, "Extended(5, [])")
+        XCTAssertEqual(MessagePackValue.extended(5, [0x00, 0x10, 0x20, 0x30, 0x40]).description, "Extended(5, [0x00, 0x10, 0x20, 0x30, 0x40])")
     }
 }

--- a/MessagePackTests/DoubleTests.swift
+++ b/MessagePackTests/DoubleTests.swift
@@ -4,17 +4,17 @@ import XCTest
 class DoubleTests: XCTestCase {
     func testLiteralConversion() {
         let implicitValue: MessagePackValue = 3.14
-        XCTAssertEqual(implicitValue, MessagePackValue.Double(3.14))
+        XCTAssertEqual(implicitValue, MessagePackValue.double(3.14))
     }
 
-    let packed: Data = [0xcb, 0x40, 0x09, 0x1e, 0xb8, 0x51, 0xeb, 0x85, 0x1f]
+    let packed: MessagePack.Data = [0xcb, 0x40, 0x09, 0x1e, 0xb8, 0x51, 0xeb, 0x85, 0x1f]
 
     func testPack() {
-        XCTAssertEqual(pack(.Double(3.14)), packed)
+        XCTAssertEqual(pack(.double(3.14)), packed)
     }
 
     func testUnpack() {
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Double(3.14))
+        XCTAssertEqual(unpacked, MessagePackValue.double(3.14))
     }
 }

--- a/MessagePackTests/EqualityTests.swift
+++ b/MessagePackTests/EqualityTests.swift
@@ -3,77 +3,77 @@ import XCTest
 
 class EqualityTests: XCTestCase {
     func testNilEqualToNil() {
-        XCTAssertEqual(MessagePackValue.Nil, MessagePackValue.Nil)
+        XCTAssertEqual(MessagePackValue.nil, MessagePackValue.nil)
     }
 
     func testNilNotEqualToBool() {
-        XCTAssertNotEqual(MessagePackValue.Nil, MessagePackValue.Bool(false))
+        XCTAssertNotEqual(MessagePackValue.nil, MessagePackValue.bool(false))
     }
 
     func testBoolEqualToBool() {
-        XCTAssertEqual(MessagePackValue.Bool(true), MessagePackValue.Bool(true))
-        XCTAssertEqual(MessagePackValue.Bool(false), MessagePackValue.Bool(false))
-        XCTAssertNotEqual(MessagePackValue.Bool(true), MessagePackValue.Bool(false))
-        XCTAssertNotEqual(MessagePackValue.Bool(false), MessagePackValue.Bool(true))
+        XCTAssertEqual(MessagePackValue.bool(true), MessagePackValue.bool(true))
+        XCTAssertEqual(MessagePackValue.bool(false), MessagePackValue.bool(false))
+        XCTAssertNotEqual(MessagePackValue.bool(true), MessagePackValue.bool(false))
+        XCTAssertNotEqual(MessagePackValue.bool(false), MessagePackValue.bool(true))
     }
 
     func testIntEqualToInt() {
-        XCTAssertEqual(MessagePackValue.Int(1), MessagePackValue.Int(1))
+        XCTAssertEqual(MessagePackValue.int(1), MessagePackValue.int(1))
     }
 
     func testUIntEqualToUInt() {
-        XCTAssertEqual(MessagePackValue.UInt(1), MessagePackValue.UInt(1))
+        XCTAssertEqual(MessagePackValue.uInt(1), MessagePackValue.uInt(1))
     }
 
     func testIntEqualToUInt() {
-        XCTAssertEqual(MessagePackValue.Int(1), MessagePackValue.UInt(1))
+        XCTAssertEqual(MessagePackValue.int(1), MessagePackValue.uInt(1))
     }
 
     func testUIntEqualToInt() {
-        XCTAssertEqual(MessagePackValue.UInt(1), MessagePackValue.Int(1))
+        XCTAssertEqual(MessagePackValue.uInt(1), MessagePackValue.int(1))
     }
 
     func testUIntNotEqualToInt() {
-        XCTAssertNotEqual(MessagePackValue.UInt(1), MessagePackValue.Int(-1))
+        XCTAssertNotEqual(MessagePackValue.uInt(1), MessagePackValue.int(-1))
     }
 
     func testIntNotEqualToUInt() {
-        XCTAssertNotEqual(MessagePackValue.Int(-1), MessagePackValue.UInt(1))
+        XCTAssertNotEqual(MessagePackValue.int(-1), MessagePackValue.uInt(1))
     }
 
     func testFloatEqualToFloat() {
-        XCTAssertEqual(MessagePackValue.Float(3.14), MessagePackValue.Float(3.14))
+        XCTAssertEqual(MessagePackValue.float(3.14), MessagePackValue.float(3.14))
     }
 
     func testDoubleEqualToDouble() {
-        XCTAssertEqual(MessagePackValue.Double(3.14), MessagePackValue.Double(3.14))
+        XCTAssertEqual(MessagePackValue.double(3.14), MessagePackValue.double(3.14))
     }
 
     func testFloatNotEqualToDouble() {
-        XCTAssertNotEqual(MessagePackValue.Float(3.14), MessagePackValue.Double(3.14))
+        XCTAssertNotEqual(MessagePackValue.float(3.14), MessagePackValue.double(3.14))
     }
 
     func testDoubleNotEqualToFloat() {
-        XCTAssertNotEqual(MessagePackValue.Double(3.14), MessagePackValue.Float(3.14))
+        XCTAssertNotEqual(MessagePackValue.double(3.14), MessagePackValue.float(3.14))
     }
 
     func testStringEqualToString() {
-        XCTAssertEqual(MessagePackValue.String("Hello, world!"), MessagePackValue.String("Hello, world!"))
+        XCTAssertEqual(MessagePackValue.string("Hello, world!"), MessagePackValue.string("Hello, world!"))
     }
 
     func testBinaryEqualToBinary() {
-        XCTAssertEqual(MessagePackValue.Binary([0x00, 0x01, 0x02, 0x03, 0x04]), MessagePackValue.Binary([0x00, 0x01, 0x02, 0x03, 0x04]))
+        XCTAssertEqual(MessagePackValue.binary([0x00, 0x01, 0x02, 0x03, 0x04]), MessagePackValue.binary([0x00, 0x01, 0x02, 0x03, 0x04]))
     }
 
     func testArrayEqualToArray() {
-        XCTAssertEqual(MessagePackValue.Array([0, 1, 2, 3, 4]), MessagePackValue.Array([0, 1, 2, 3, 4]))
+        XCTAssertEqual(MessagePackValue.array([0, 1, 2, 3, 4]), MessagePackValue.array([0, 1, 2, 3, 4]))
     }
 
     func testMapEqualToMap() {
-        XCTAssertEqual(MessagePackValue.Map(["a": "apple", "b": "banana", "c": "cookie"]), MessagePackValue.Map(["b": "banana", "c": "cookie", "a": "apple"]))
+        XCTAssertEqual(MessagePackValue.map(["a": "apple", "b": "banana", "c": "cookie"]), MessagePackValue.map(["b": "banana", "c": "cookie", "a": "apple"]))
     }
 
     func testExtendedEqualToExtended() {
-        XCTAssertEqual(MessagePackValue.Extended(5, [0x00, 0x01, 0x02, 0x03, 0x04]), MessagePackValue.Extended(5, [0x00, 0x01, 0x02, 0x03, 0x04]))
+        XCTAssertEqual(MessagePackValue.extended(5, [0x00, 0x01, 0x02, 0x03, 0x04]), MessagePackValue.extended(5, [0x00, 0x01, 0x02, 0x03, 0x04]))
     }
 }

--- a/MessagePackTests/ExtendedTests.swift
+++ b/MessagePackTests/ExtendedTests.swift
@@ -3,119 +3,119 @@ import XCTest
 
 class ExtendedTests: XCTestCase {
     func testPackFixext1() {
-        let value = MessagePackValue.Extended(5, [0x00])
-        let packed: Data = [0xd4, 0x05, 0x00]
+        let value = MessagePackValue.extended(5, [0x00])
+        let packed: MessagePack.Data = [0xd4, 0x05, 0x00]
         XCTAssertEqual(pack(value), packed)
     }
 
     func testUnpackFixext1() {
-        let packed: Data = [0xd4, 0x05, 0x00]
-        let value = MessagePackValue.Extended(5, [0x00])
+        let packed: MessagePack.Data = [0xd4, 0x05, 0x00]
+        let value = MessagePackValue.extended(5, [0x00])
 
         let unpacked = try? unpack(packed)
         XCTAssertEqual(unpacked, value)
     }
 
     func testPackFixext2() {
-        let value = MessagePackValue.Extended(5, [0x00, 0x01])
-        let packed: Data = [0xd5, 0x05, 0x00, 0x01]
+        let value = MessagePackValue.extended(5, [0x00, 0x01])
+        let packed: MessagePack.Data = [0xd5, 0x05, 0x00, 0x01]
         XCTAssertEqual(pack(value), packed)
     }
 
     func testUnpackFixext2() {
-        let packed: Data = [0xd5, 0x05, 0x00, 0x01]
-        let value = MessagePackValue.Extended(5, [0x00, 0x01])
+        let packed: MessagePack.Data = [0xd5, 0x05, 0x00, 0x01]
+        let value = MessagePackValue.extended(5, [0x00, 0x01])
 
         let unpacked = try? unpack(packed)
         XCTAssertEqual(unpacked, value)
     }
 
     func testPackFixext4() {
-        let value = MessagePackValue.Extended(5, [0x00, 0x01, 0x02, 0x03])
-        let packed: Data = [0xd6, 0x05, 0x00, 0x01, 0x02, 0x03]
+        let value = MessagePackValue.extended(5, [0x00, 0x01, 0x02, 0x03])
+        let packed: MessagePack.Data = [0xd6, 0x05, 0x00, 0x01, 0x02, 0x03]
         XCTAssertEqual(pack(value), packed)
     }
 
     func testUnpackFixext4() {
-        let packed: Data = [0xd6, 0x05, 0x00, 0x01, 0x02, 0x03]
-        let value = MessagePackValue.Extended(5, [0x00, 0x01, 0x02, 0x03])
+        let packed: MessagePack.Data = [0xd6, 0x05, 0x00, 0x01, 0x02, 0x03]
+        let value = MessagePackValue.extended(5, [0x00, 0x01, 0x02, 0x03])
 
         let unpacked = try? unpack(packed)
         XCTAssertEqual(unpacked, value)
     }
 
     func testPackFixext8() {
-        let value = MessagePackValue.Extended(5, [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
-        let packed: Data = [0xd7, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+        let value = MessagePackValue.extended(5, [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
+        let packed: MessagePack.Data = [0xd7, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
         XCTAssertEqual(pack(value), packed)
     }
 
     func testUnpackFixext8() {
-        let packed: Data = [0xd7, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
-        let value = MessagePackValue.Extended(5, [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
+        let packed: MessagePack.Data = [0xd7, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+        let value = MessagePackValue.extended(5, [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
 
         let unpacked = try? unpack(packed)
         XCTAssertEqual(unpacked, value)
     }
 
     func testPackFixext16() {
-        let value = MessagePackValue.Extended(5, [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f])
-        let packed: Data = [0xd8, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]
+        let value = MessagePackValue.extended(5, [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f])
+        let packed: MessagePack.Data = [0xd8, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]
         XCTAssertEqual(pack(value), packed)
     }
 
     func testUnpackFixext16() {
-        let value = MessagePackValue.Extended(5, [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f])
-        let packed: Data = [0xd8, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]
+        let value = MessagePackValue.extended(5, [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f])
+        let packed: MessagePack.Data = [0xd8, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]
 
         let unpacked = try? unpack(packed)
         XCTAssertEqual(unpacked, value)
     }
 
     func testPackExt8() {
-        let payload = Data(count: 7, repeatedValue: 0)
-        let value = MessagePackValue.Extended(5, payload)
+        let payload = MessagePack.Data(repeating: 0, count: 7)
+        let value = MessagePackValue.extended(5, payload)
         XCTAssertEqual(pack(value), [0xc7, 0x07, 0x05] + payload)
     }
 
     func testUnpackExt8() {
-        let payload = Data(count: 7, repeatedValue: 0)
-        let value = MessagePackValue.Extended(5, payload)
+        let payload = MessagePack.Data(repeating: 0, count: 7)
+        let value = MessagePackValue.extended(5, payload)
 
         let unpacked = try? unpack([0xc7, 0x07, 0x05] + payload)
         XCTAssertEqual(unpacked, value)
     }
 
     func testPackExt16() {
-        let payload = Data(count: 0x100, repeatedValue: 0)
-        let value = MessagePackValue.Extended(5, payload)
+        let payload = MessagePack.Data(repeating: 0, count: 0x100)
+        let value = MessagePackValue.extended(5, payload)
         XCTAssertEqual(pack(value), [0xc8, 0x01, 0x00, 0x05] + payload)
     }
 
     func testUnpackExt16() {
-        let payload = Data(count: 0x100, repeatedValue: 0)
-        let value = MessagePackValue.Extended(5, payload)
+        let payload = MessagePack.Data(repeating: 0, count: 0x100)
+        let value = MessagePackValue.extended(5, payload)
 
         let unpacked = try? unpack([0xc8, 0x01, 0x00, 0x05] + payload)
         XCTAssertEqual(unpacked, value)
     }
 
     func testPackExt32() {
-        let payload = Data(count: 0x10000, repeatedValue: 0)
-        let value = MessagePackValue.Extended(5, payload)
+        let payload = MessagePack.Data(repeating: 0, count: 0x10000)
+        let value = MessagePackValue.extended(5, payload)
         XCTAssertEqual(pack(value), [0xc9, 0x00, 0x01, 0x00, 0x00, 0x05] + payload)
     }
 
     func testUnpackExt32() {
-        let payload = Data(count: 0x10000, repeatedValue: 0)
-        let value = MessagePackValue.Extended(5, payload)
+        let payload = MessagePack.Data(repeating: 0, count: 0x10000)
+        let value = MessagePackValue.extended(5, payload)
 
         let unpacked = try? unpack([0xc9, 0x00, 0x01, 0x00, 0x00, 0x05] + payload)
         XCTAssertEqual(unpacked, value)
     }
 
     func testUnpackInsufficientData() {
-        let dataArray: [Data] = [
+        let dataArray: [MessagePack.Data] = [
             // fixent
             [0xd4], [0xd5], [0xd6], [0xd7], [0xd8],
 
@@ -124,10 +124,10 @@ class ExtendedTests: XCTestCase {
         ]
         for data in dataArray {
             do {
-                try unpack(data)
+                let _ = try unpack(data)
                 XCTFail("Expected unpack to throw")
             } catch {
-                XCTAssertEqual(error as? MessagePackError, .InsufficientData)
+                XCTAssertEqual(error as? MessagePackError, .insufficientData)
             }
         }
     }

--- a/MessagePackTests/FalseTests.swift
+++ b/MessagePackTests/FalseTests.swift
@@ -2,19 +2,19 @@
 import XCTest
 
 class FalseTests: XCTestCase {
-    let packed: Data = [0xc2]
+    let packed: MessagePack.Data = [0xc2]
 
     func testLiteralConversion() {
         let implicitValue: MessagePackValue = false
-        XCTAssertEqual(implicitValue, MessagePackValue.Bool(false))
+        XCTAssertEqual(implicitValue, MessagePackValue.bool(false))
     }
 
     func testPack() {
-        XCTAssertEqual(pack(.Bool(false)), packed)
+        XCTAssertEqual(pack(.bool(false)), packed)
     }
 
     func testUnpack() {
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Bool(false))
+        XCTAssertEqual(unpacked, MessagePackValue.bool(false))
     }
 }

--- a/MessagePackTests/FloatTests.swift
+++ b/MessagePackTests/FloatTests.swift
@@ -2,14 +2,14 @@
 import XCTest
 
 class FloatTests: XCTestCase {
-    let packed: Data = [0xca, 0x40, 0x48, 0xf5, 0xc3]
+    let packed: MessagePack.Data = [0xca, 0x40, 0x48, 0xf5, 0xc3]
 
     func testPack() {
-        XCTAssertEqual(pack(.Float(3.14)), packed)
+        XCTAssertEqual(pack(.float(3.14)), packed)
     }
 
     func testUnpack() {
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Float(3.14))
+        XCTAssertEqual(unpacked, MessagePackValue.float(3.14))
     }
 }

--- a/MessagePackTests/HashValueTests.swift
+++ b/MessagePackTests/HashValueTests.swift
@@ -3,51 +3,51 @@ import XCTest
 
 class HashValueTests: XCTestCase {
     func testNilHashValue() {
-        XCTAssertEqual(MessagePackValue.Nil.hashValue, 0)
+        XCTAssertEqual(MessagePackValue.nil.hashValue, 0)
     }
 
     func testBoolHashValue() {
-        XCTAssertEqual(MessagePackValue.Bool(true).hashValue, true.hashValue)
-        XCTAssertEqual(MessagePackValue.Bool(false).hashValue, false.hashValue)
+        XCTAssertEqual(MessagePackValue.bool(true).hashValue, true.hashValue)
+        XCTAssertEqual(MessagePackValue.bool(false).hashValue, false.hashValue)
     }
 
     func testIntHashValue() {
-        XCTAssertEqual(MessagePackValue.Int(-1).hashValue, Int64(-1).hashValue)
-        XCTAssertEqual(MessagePackValue.Int(0).hashValue, Int64(0).hashValue)
-        XCTAssertEqual(MessagePackValue.Int(1).hashValue, Int64(1).hashValue)
+        XCTAssertEqual(MessagePackValue.int(-1).hashValue, Int64(-1).hashValue)
+        XCTAssertEqual(MessagePackValue.int(0).hashValue, Int64(0).hashValue)
+        XCTAssertEqual(MessagePackValue.int(1).hashValue, Int64(1).hashValue)
     }
 
     func testUIntHashValue() {
-        XCTAssertEqual(MessagePackValue.UInt(0).hashValue, UInt64(0).hashValue)
-        XCTAssertEqual(MessagePackValue.UInt(1).hashValue, UInt64(1).hashValue)
-        XCTAssertEqual(MessagePackValue.UInt(2).hashValue, UInt64(2).hashValue)
+        XCTAssertEqual(MessagePackValue.uInt(0).hashValue, UInt64(0).hashValue)
+        XCTAssertEqual(MessagePackValue.uInt(1).hashValue, UInt64(1).hashValue)
+        XCTAssertEqual(MessagePackValue.uInt(2).hashValue, UInt64(2).hashValue)
     }
 
     func testFloatHashValue() {
-        XCTAssertEqual(MessagePackValue.Float(0).hashValue, Float(0).hashValue)
-        XCTAssertEqual(MessagePackValue.Float(1.618).hashValue, Float(1.618).hashValue)
-        XCTAssertEqual(MessagePackValue.Float(3.14).hashValue, Float(3.14).hashValue)
+        XCTAssertEqual(MessagePackValue.float(0).hashValue, Float(0).hashValue)
+        XCTAssertEqual(MessagePackValue.float(1.618).hashValue, Float(1.618).hashValue)
+        XCTAssertEqual(MessagePackValue.float(3.14).hashValue, Float(3.14).hashValue)
     }
 
     func testDoubleHashValue() {
-        XCTAssertEqual(MessagePackValue.Double(0).hashValue, Double(0).hashValue)
-        XCTAssertEqual(MessagePackValue.Double(1.618).hashValue, Double(1.618).hashValue)
-        XCTAssertEqual(MessagePackValue.Double(3.14).hashValue, Double(3.14).hashValue)
+        XCTAssertEqual(MessagePackValue.double(0).hashValue, Double(0).hashValue)
+        XCTAssertEqual(MessagePackValue.double(1.618).hashValue, Double(1.618).hashValue)
+        XCTAssertEqual(MessagePackValue.double(3.14).hashValue, Double(3.14).hashValue)
     }
 
     func testStringHashValue() {
-        XCTAssertEqual(MessagePackValue.String("").hashValue, "".hashValue)
-        XCTAssertEqual(MessagePackValue.String("MessagePack").hashValue, "MessagePack".hashValue)
+        XCTAssertEqual(MessagePackValue.string("").hashValue, "".hashValue)
+        XCTAssertEqual(MessagePackValue.string("MessagePack").hashValue, "MessagePack".hashValue)
     }
 
     func testBinaryHashValue() {
-        XCTAssertEqual(MessagePackValue.Binary([]).hashValue, 0)
-        XCTAssertEqual(MessagePackValue.Binary([0x00, 0x01, 0x02, 0x03, 0x04]).hashValue, 5)
+        XCTAssertEqual(MessagePackValue.binary([]).hashValue, 0)
+        XCTAssertEqual(MessagePackValue.binary([0x00, 0x01, 0x02, 0x03, 0x04]).hashValue, 5)
     }
 
     func testArrayHashValue() {
         let values: [MessagePackValue] = [1, true, ""]
-        XCTAssertEqual(MessagePackValue.Array(values).hashValue, 3)
+        XCTAssertEqual(MessagePackValue.array(values).hashValue, 3)
     }
 
     func testMapHashValue() {
@@ -56,11 +56,11 @@ class HashValueTests: XCTestCase {
             "b": "banana",
             "c": "cookie",
         ]
-        XCTAssertEqual(MessagePackValue.Map(values).hashValue, 3)
+        XCTAssertEqual(MessagePackValue.map(values).hashValue, 3)
     }
 
     func testExtendedHashValue() {
-        XCTAssertEqual(MessagePackValue.Extended(5, []).hashValue, Int(5).hashValue ^ Int(0))
-        XCTAssertEqual(MessagePackValue.Extended(5, [0x00, 0x01, 0x02, 0x03, 0x04]).hashValue, Int(5).hashValue ^ Int(5))
+        XCTAssertEqual(MessagePackValue.extended(5, []).hashValue, Int(5).hashValue ^ Int(0))
+        XCTAssertEqual(MessagePackValue.extended(5, [0x00, 0x01, 0x02, 0x03, 0x04]).hashValue, Int(5).hashValue ^ Int(5))
     }
 }

--- a/MessagePackTests/IntegerTests.swift
+++ b/MessagePackTests/IntegerTests.swift
@@ -4,124 +4,124 @@ import XCTest
 class IntegerTests: XCTestCase {
     func testPosLiteralConversion() {
         let implicitValue: MessagePackValue = -1
-        XCTAssertEqual(implicitValue, MessagePackValue.Int(-1))
+        XCTAssertEqual(implicitValue, MessagePackValue.int(-1))
     }
 
     func testNegLiteralConversion() {
         let implicitValue: MessagePackValue = 42
-        XCTAssertEqual(implicitValue, MessagePackValue.UInt(42))
+        XCTAssertEqual(implicitValue, MessagePackValue.uInt(42))
     }
 
     func testPackNegFixint() {
-        XCTAssertEqual(pack(.Int(-1)), [0xff])
+        XCTAssertEqual(pack(.int(-1)), [0xff])
     }
 
     func testUnpackNegFixint() {
         let unpacked1 = try? unpack([0xff])
-        XCTAssertEqual(unpacked1, MessagePackValue.Int(-1))
+        XCTAssertEqual(unpacked1, MessagePackValue.int(-1))
 
         let unpacked2 = try? unpack([0xe0])
-        XCTAssertEqual(unpacked2, MessagePackValue.Int(-32))
+        XCTAssertEqual(unpacked2, MessagePackValue.int(-32))
     }
 
     func testPackPosFixintSigned() {
-        XCTAssertEqual(pack(.Int(1)), [0x01])
+        XCTAssertEqual(pack(.int(1)), [0x01])
     }
 
     func testUnpackPosFixintSigned() {
         let unpacked = try? unpack([0x01])
-        XCTAssertEqual(unpacked, MessagePackValue.Int(1))
+        XCTAssertEqual(unpacked, MessagePackValue.int(1))
     }
 
     func testPackPosFixintUnsigned() {
-        XCTAssertEqual(pack(.UInt(42)), [0x2a])
+        XCTAssertEqual(pack(.uInt(42)), [0x2a])
     }
 
     func testUnpackPosFixintUnsigned() {
         let unpacked = try? unpack([0x2a])
-        XCTAssertEqual(unpacked, MessagePackValue.UInt(42))
+        XCTAssertEqual(unpacked, MessagePackValue.uInt(42))
     }
 
     func testPackUInt8() {
-        XCTAssertEqual(pack(.UInt(0xff)), [0xcc, 0xff])
+        XCTAssertEqual(pack(.uInt(0xff)), [0xcc, 0xff])
     }
 
     func testUnpackUInt8() {
         let unpacked = try? unpack([0xcc, 0xff])
-        XCTAssertEqual(unpacked, MessagePackValue.UInt(0xff))
+        XCTAssertEqual(unpacked, MessagePackValue.uInt(0xff))
     }
 
     func testPackUInt16() {
-        XCTAssertEqual(pack(.UInt(0xffff)), [0xcd, 0xff, 0xff])
+        XCTAssertEqual(pack(.uInt(0xffff)), [0xcd, 0xff, 0xff])
     }
 
     func testUnpackUInt16() {
         let unpacked = try? unpack([0xcd, 0xff, 0xff])
-        XCTAssertEqual(unpacked, MessagePackValue.UInt(0xffff))
+        XCTAssertEqual(unpacked, MessagePackValue.uInt(0xffff))
     }
 
     func testPackUInt32() {
-        XCTAssertEqual(pack(.UInt(0xffff_ffff)), [0xce, 0xff, 0xff, 0xff, 0xff])
+        XCTAssertEqual(pack(.uInt(0xffff_ffff)), [0xce, 0xff, 0xff, 0xff, 0xff])
     }
 
     func testUnpackUInt32() {
         let unpacked = try? unpack([0xce, 0xff, 0xff, 0xff, 0xff])
-        XCTAssertEqual(unpacked, MessagePackValue.UInt(0xffff_ffff))
+        XCTAssertEqual(unpacked, MessagePackValue.uInt(0xffff_ffff))
     }
 
     func testPackUInt64() {
-        XCTAssertEqual(pack(.UInt(0xffff_ffff_ffff_ffff)), [0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
+        XCTAssertEqual(pack(.uInt(0xffff_ffff_ffff_ffff)), [0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
     }
 
     func testUnpackUInt64() {
         let unpacked = try? unpack([0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
-        XCTAssertEqual(unpacked, MessagePackValue.UInt(0xffff_ffff_ffff_ffff))
+        XCTAssertEqual(unpacked, MessagePackValue.uInt(0xffff_ffff_ffff_ffff))
     }
 
     func testPackInt8() {
-        XCTAssertEqual(pack(.Int(-0x7f)), [0xd0, 0x81])
+        XCTAssertEqual(pack(.int(-0x7f)), [0xd0, 0x81])
     }
 
     func testUnpackInt8() {
         let unpacked = try? unpack([0xd0, 0x81])
-        XCTAssertEqual(unpacked, MessagePackValue.Int(-0x7f))
+        XCTAssertEqual(unpacked, MessagePackValue.int(-0x7f))
     }
 
     func testPackInt16() {
-        XCTAssertEqual(pack(.Int(-0x7fff)), [0xd1, 0x80, 0x01])
+        XCTAssertEqual(pack(.int(-0x7fff)), [0xd1, 0x80, 0x01])
     }
 
     func testUnpackInt16() {
         let unpacked = try? unpack([0xd1, 0x80, 0x01])
-        XCTAssertEqual(unpacked, MessagePackValue.Int(-0x7fff))
+        XCTAssertEqual(unpacked, MessagePackValue.int(-0x7fff))
     }
 
     func testPackInt32() {
-        XCTAssertEqual(pack(.Int(-0x1_0000)), [0xd2, 0xff, 0xff, 0x00, 0x00])
+        XCTAssertEqual(pack(.int(-0x1_0000)), [0xd2, 0xff, 0xff, 0x00, 0x00])
     }
 
     func testUnpackInt32() {
         let unpacked = try? unpack([0xd2, 0xff, 0xff, 0x00, 0x00])
-        XCTAssertEqual(unpacked, MessagePackValue.Int(-0x1_0000))
+        XCTAssertEqual(unpacked, MessagePackValue.int(-0x1_0000))
     }
 
     func testPackInt64() {
-        XCTAssertEqual(pack(.Int(-0x1_0000_0000)), [0xd3, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00])
+        XCTAssertEqual(pack(.int(-0x1_0000_0000)), [0xd3, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00])
     }
 
     func testUnpackInt64() {
         let unpacked = try? unpack([0xd3, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00])
-        XCTAssertEqual(unpacked, MessagePackValue.Int(-0x1_0000_0000))
+        XCTAssertEqual(unpacked, MessagePackValue.int(-0x1_0000_0000))
     }
 
     func testUnpackInsufficientData() {
-        let dataArray: [Data] = [[0xd0], [0xd1], [0xd2], [0xd3], [0xd4]]
+        let dataArray: [MessagePack.Data] = [[0xd0], [0xd1], [0xd2], [0xd3], [0xd4]]
         for data in dataArray {
             do {
-                try unpack(data)
+                let _ = try unpack(data)
                 XCTFail("Expected unpack to throw")
             } catch {
-                XCTAssertEqual(error as? MessagePackError, .InsufficientData)
+                XCTAssertEqual(error as? MessagePackError, .insufficientData)
             }
         }
     }

--- a/MessagePackTests/MapTests.swift
+++ b/MessagePackTests/MapTests.swift
@@ -1,28 +1,28 @@
 @testable import MessagePack
 import XCTest
 
-func map(count: Int) -> [MessagePackValue : MessagePackValue] {
+func map(_ count: Int) -> [MessagePackValue : MessagePackValue] {
     var dict = [MessagePackValue : MessagePackValue]()
     for i in 0..<count {
-        dict[.Int(numericCast(i))] = .Nil
+        dict[.int(numericCast(i))] = .nil
     }
 
     return dict
 }
 
-func payload(count: Int) -> Data {
-    var data = Data()
+func payload(_ count: Int) -> MessagePack.Data {
+    var data = MessagePack.Data()
     for i in 0..<count {
-        data += pack(.Int(numericCast(i))) + pack(.Nil)
+        data += pack(.int(numericCast(i))) + pack(.nil)
     }
     
     return data
 }
 
-func testPackMap(count: Int, prefix: Data) {
-    let packed = pack(.Map(map(count)))
+func testPackMap(_ count: Int, prefix: MessagePack.Data) {
+    let packed = pack(.map(map(count)))
 
-    var generator = packed.generate()
+    var generator = packed.makeIterator()
     for expectedByte in prefix {
         let byte = generator.next()!
         XCTAssertEqual(byte, expectedByte)
@@ -37,7 +37,7 @@ func testPackMap(count: Int, prefix: Data) {
         keys.insert(key)
 
         let nilValue = try! unpack(&generator)
-        XCTAssertEqual(nilValue, MessagePackValue.Nil)
+        XCTAssertEqual(nilValue, MessagePackValue.nil)
     }
     
     XCTAssertEqual(keys.count, count)
@@ -46,19 +46,19 @@ func testPackMap(count: Int, prefix: Data) {
 class MapTests: XCTestCase {
     func testLiteralConversion() {
         let implicitValue: MessagePackValue = ["c": "cookie"]
-        XCTAssertEqual(implicitValue, MessagePackValue.Map([.String("c"): .String("cookie")]))
+        XCTAssertEqual(implicitValue, MessagePackValue.map([.string("c"): .string("cookie")]))
     }
 
     func testPackFixmap() {
-        let packed: Data = [0x81, 0xa1, 0x63, 0xa6, 0x63, 0x6f, 0x6f, 0x6b, 0x69, 0x65]
-        XCTAssertEqual(pack(.Map([.String("c"): .String("cookie")])), packed)
+        let packed: MessagePack.Data = [0x81, 0xa1, 0x63, 0xa6, 0x63, 0x6f, 0x6f, 0x6b, 0x69, 0x65]
+        XCTAssertEqual(pack(.map([.string("c"): .string("cookie")])), packed)
     }
 
     func testUnpackFixmap() {
-        let packed: Data = [0x81, 0xa1, 0x63, 0xa6, 0x63, 0x6f, 0x6f, 0x6b, 0x69, 0x65]
+        let packed: MessagePack.Data = [0x81, 0xa1, 0x63, 0xa6, 0x63, 0x6f, 0x6f, 0x6b, 0x69, 0x65]
 
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Map([.String("c"): .String("cookie")]))
+        XCTAssertEqual(unpacked, MessagePackValue.map([.string("c"): .string("cookie")]))
     }
 
     func testPackMap16() {
@@ -67,7 +67,7 @@ class MapTests: XCTestCase {
 
     func testUnpackMap16() {
         let unpacked = try? unpack([0xde, 0x00, 0x10] + payload(16))
-        XCTAssertEqual(unpacked, MessagePackValue.Map(map(16)))
+        XCTAssertEqual(unpacked, MessagePackValue.map(map(16)))
     }
 
     func testPackMap32() {
@@ -76,6 +76,6 @@ class MapTests: XCTestCase {
 
     func testUnpackMap32() {
         let unpacked = try? unpack([0xdf, 0x00, 0x01, 0x00, 0x00] + payload(0x1_0000))
-        XCTAssertEqual(unpacked, MessagePackValue.Map(map(0x1_0000)))
+        XCTAssertEqual(unpacked, MessagePackValue.map(map(0x1_0000)))
     }
 }

--- a/MessagePackTests/NilTests.swift
+++ b/MessagePackTests/NilTests.swift
@@ -2,19 +2,19 @@
 import XCTest
 
 class NilTests: XCTestCase {
-    let packed: Data = [0xc0]
+    let packed: MessagePack.Data = [0xc0]
 
     func testLiteralConversion() {
         let implicitValue: MessagePackValue = nil
-        XCTAssertEqual(implicitValue, MessagePackValue.Nil)
+        XCTAssertEqual(implicitValue, MessagePackValue.nil)
     }
 
     func testPack() {
-        XCTAssertEqual(pack(.Nil), packed)
+        XCTAssertEqual(pack(.nil), packed)
     }
 
     func testUnpack() {
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Nil)
+        XCTAssertEqual(unpacked, MessagePackValue.nil)
     }
 }

--- a/MessagePackTests/StringTests.swift
+++ b/MessagePackTests/StringTests.swift
@@ -1,19 +1,19 @@
 @testable import MessagePack
 import XCTest
 
-func string(length: Int, repeatedValue: String = "*") -> String {
+func string(_ length: Int, repeatedValue: String = "*") -> String {
     var str = ""
     str.reserveCapacity(length * repeatedValue.characters.count)
 
     for _ in 0..<length {
-        str.appendContentsOf(repeatedValue)
+        str.append(repeatedValue)
     }
 
     return str
 }
 
-func data(string: String) -> ArraySlice<Byte> {
-    return string.nulTerminatedUTF8.dropLast()
+func data(_ string: String) -> Foundation.Data {
+    return Data(string.utf8)
 }
 
 class StringTests: XCTestCase {
@@ -21,30 +21,30 @@ class StringTests: XCTestCase {
         var implicitValue: MessagePackValue
 
         implicitValue = "Hello, world!"
-        XCTAssertEqual(implicitValue, MessagePackValue.String("Hello, world!"))
+        XCTAssertEqual(implicitValue, MessagePackValue.string("Hello, world!"))
 
         implicitValue = MessagePackValue(extendedGraphemeClusterLiteral: "Hello, world!")
-        XCTAssertEqual(implicitValue, MessagePackValue.String("Hello, world!"))
+        XCTAssertEqual(implicitValue, MessagePackValue.string("Hello, world!"))
 
         implicitValue = MessagePackValue(unicodeScalarLiteral: "Hello, world!")
-        XCTAssertEqual(implicitValue, MessagePackValue.String("Hello, world!"))
+        XCTAssertEqual(implicitValue, MessagePackValue.string("Hello, world!"))
     }
 
     func testPackFixstr() {
-        let packed: Data = [0xad, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]
-        XCTAssertEqual(pack(.String("Hello, world!")), packed)
+        let packed: MessagePack.Data = [0xad, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]
+        XCTAssertEqual(pack(.string("Hello, world!")), packed)
     }
 
     func testUnpackFixstr() {
-        let packed: Data = [0xad, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]
+        let packed: MessagePack.Data = [0xad, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]
 
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.String("Hello, world!"))
+        XCTAssertEqual(unpacked, MessagePackValue.string("Hello, world!"))
     }
 
     func testPackStr8() {
         let str = string(0x20)
-        XCTAssertEqual(pack(.String(str)), [0xd9, 0x20] + data(str))
+        XCTAssertEqual(pack(.string(str)), [0xd9, 0x20] + data(str))
     }
 
     func testUnpackStr8() {
@@ -52,12 +52,12 @@ class StringTests: XCTestCase {
         let packed = [0xd9, 0x20] + data(str)
 
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.String(str))
+        XCTAssertEqual(unpacked, MessagePackValue.string(str))
     }
 
     func testPackStr16() {
         let str = string(0x1000)
-        XCTAssertEqual(pack(.String(str)), [0xda, 0x10, 0x00] + data(str))
+        XCTAssertEqual(pack(.string(str)), [0xda, 0x10, 0x00] + data(str))
     }
 
     func testUnpackStr16() {
@@ -65,12 +65,12 @@ class StringTests: XCTestCase {
         let packed = [0xda, 0x10, 0x00] + data(str)
 
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.String(str))
+        XCTAssertEqual(unpacked, MessagePackValue.string(str))
     }
 
     func testPackStr32() {
         let str = string(0x10000)
-        XCTAssertEqual(pack(.String(str)), [0xdb, 0x00, 0x01, 0x00, 0x00] + data(str))
+        XCTAssertEqual(pack(.string(str)), [0xdb, 0x00, 0x01, 0x00, 0x00] + data(str))
     }
 
     func testUnpackStr32() {
@@ -78,6 +78,6 @@ class StringTests: XCTestCase {
         let packed = [0xdb, 0x00, 0x01, 0x00, 0x00] + data(str)
 
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.String(str))
+        XCTAssertEqual(unpacked, MessagePackValue.string(str))
     }
 }

--- a/MessagePackTests/TrueTests.swift
+++ b/MessagePackTests/TrueTests.swift
@@ -2,19 +2,19 @@
 import XCTest
 
 class TrueTests: XCTestCase {
-    let packed: Data = [0xc3]
+    let packed: MessagePack.Data = [0xc3]
 
     func testLiteralConversion() {
         let implicitValue: MessagePackValue = true
-        XCTAssertEqual(implicitValue, MessagePackValue.Bool(true))
+        XCTAssertEqual(implicitValue, MessagePackValue.bool(true))
     }
 
     func testPack() {
-        XCTAssertEqual(pack(.Bool(true)), packed)
+        XCTAssertEqual(pack(.bool(true)), packed)
     }
 
     func testUnpack() {
         let unpacked = try? unpack(packed)
-        XCTAssertEqual(unpacked, MessagePackValue.Bool(true))
+        XCTAssertEqual(unpacked, MessagePackValue.bool(true))
     }
 }


### PR DESCRIPTION
The only API change should be the lowercasing of enum names, aside from changes in the standard library. All tests pass.

Fixes #32
