### PR TITLE
Fix exception on empty string

### DIFF
--- a/Sources/MessagePack/Unpack.swift
+++ b/Sources/MessagePack/Unpack.swift
@@ -32,7 +32,7 @@ func unpackInteger(_ data: Data, count: Int) throws -> (value: UInt64, remainder
 /// - returns: A string representation of `size` bytes of data.
 func unpackString(_ data: Data, count: Int) throws -> (value: String, remainder: Data) {
     guard count > 0 else {
-        throw MessagePackError.invalidArgument
+        return ("", data)
     }
 
     guard data.count >= count else {

--- a/Tests/MessagePackTests/StringTests.swift
+++ b/Tests/MessagePackTests/StringTests.swift
@@ -8,6 +8,7 @@ class StringTests: XCTestCase {
             ("testLiteralConversion", testLiteralConversion),
             ("testPackFixstr", testPackFixstr),
             ("testUnpackFixstr", testUnpackFixstr),
+            ("testUnpackFixstrEmpty", testUnpackFixstrEmpty),
             ("testPackStr8", testPackStr8),
             ("testUnpackStr8", testUnpackStr8),
             ("testPackStr16", testPackStr16),
@@ -43,6 +44,14 @@ class StringTests: XCTestCase {
         XCTAssertEqual(unpacked?.remainder.count, 0)
     }
 
+    func testUnpackFixstrEmpty() {
+        let packed = Data([0xa0])
+        
+        let unpacked = try? unpack(packed)
+        XCTAssertEqual(unpacked?.value, .string(""))
+        XCTAssertEqual(unpacked?.remainder.count, 0)
+    }
+  
     func testPackStr8() {
         let string = String(repeating: "*", count: 0x20)
         XCTAssertEqual(pack(.string(string)), Data([0xd9, 0x20]) + string.data(using: .utf8)!)


### PR DESCRIPTION
Currently, when an empty string is contained in the message pack the code will throw an exception. This seems like the wrong behaviour as I believe an empty string is completely valid (`0xa0`).

This change returns an empty string `""` when a count of 0 is found.
