### PR TITLE
Fix memory consumption during unpack

### DIFF
--- a/Sources/MessagePack/Unpack.swift
+++ b/Sources/MessagePack/Unpack.swift
@@ -113,8 +113,8 @@ public func unpack(_ data: Data, compatibility: Bool = false) throws -> (value: 
         throw MessagePackError.insufficientData
     }
 
-    var data = data
-    let value = data.removeFirst()
+    let value = data.first!
+    let data = data.subdata(in: 1..<data.endIndex)
 
     switch value {
 

--- a/Sources/MessagePack/Unpack.swift
+++ b/Sources/MessagePack/Unpack.swift
@@ -114,7 +114,7 @@ public func unpack(_ data: Data, compatibility: Bool = false) throws -> (value: 
     }
 
     let value = data.first!
-    let data = data.subdata(in: 1..<data.endIndex)
+    let data = data.subdata(in: 1 ..< data.endIndex)
 
     switch value {
 


### PR DESCRIPTION
`removeFirst` causes a data copy which can very quickly grow memory since this method may be called hundreds of thousands of times. I can escalate my machine to many GB of memory in a couple seconds when unpacking large arrays.

The fix uses a subdata call to avoid the copy issue.
