### PR TITLE
Improve performance of unpackArray

### DIFF
--- a/Sources/MessagePack/Unpack.swift
+++ b/Sources/MessagePack/Unpack.swift
@@ -73,13 +73,15 @@ func unpackData(_ data: Data, count: Int) throws -> (value: Data, remainder: Dat
 ///
 /// - returns: An array of `count` elements.
 func unpackArray(_ data: Data, count: Int, compatibility: Bool) throws -> (value: [MessagePackValue], remainder: Data) {
-    var values:[MessagePackValue] = []
-    var newValue:MessagePackValue
-    var remainder:Data = data
+    var values = [MessagePackValue]())
+    var remainder = data
+    var newValue: MessagePackValue
+
     for _ in 0 ..< count {
         (newValue, remainder) = try unpack(remainder, compatibility: compatibility)
         values.append(newValue)
     }
+
     return (values, remainder)
 }
 

--- a/Sources/MessagePack/Unpack.swift
+++ b/Sources/MessagePack/Unpack.swift
@@ -73,11 +73,14 @@ func unpackData(_ data: Data, count: Int) throws -> (value: Data, remainder: Dat
 ///
 /// - returns: An array of `count` elements.
 func unpackArray(_ data: Data, count: Int, compatibility: Bool) throws -> (value: [MessagePackValue], remainder: Data) {
-    let initialResult: (value: [MessagePackValue], remainder: Data) = ([], data)
-    return try (0 ..< count).reduce(initialResult) { result, _ in
-        let (value, remainder) = try unpack(result.remainder, compatibility: compatibility)
-        return (result.value + [value], remainder)
+    var values:[MessagePackValue] = []
+    var newValue:MessagePackValue
+    var remainder:Data = data
+    for _ in 0 ..< count {
+        (newValue, remainder) = try unpack(remainder, compatibility: compatibility)
+        values.append(newValue)
     }
+    return (values, remainder)
 }
 
 /// Joins bytes to form a dictionary with `MessagePackValue` key/value entries.

--- a/Sources/MessagePack/Unpack.swift
+++ b/Sources/MessagePack/Unpack.swift
@@ -73,7 +73,7 @@ func unpackData(_ data: Data, count: Int) throws -> (value: Data, remainder: Dat
 ///
 /// - returns: An array of `count` elements.
 func unpackArray(_ data: Data, count: Int, compatibility: Bool) throws -> (value: [MessagePackValue], remainder: Data) {
-    var values = [MessagePackValue]())
+    var values = [MessagePackValue]()
     var remainder = data
     var newValue: MessagePackValue
 


### PR DESCRIPTION
Unpacking became many times slower after the Swift 3.0 update. Using reduce to unpack a very large array slows performance. Switching to a for loop increases performance by ~10x.

For Example, a 40k element double array goes from 0.8s to 0.08s
