### PR TITLE
add Raw Type (packed data)

### DIFF
--- a/MessagePack.xcodeproj/project.pbxproj
+++ b/MessagePack.xcodeproj/project.pbxproj
@@ -16,11 +16,11 @@
             "en",
          );
          mainGroup = OBJ_5;
-         productRefGroup = OBJ_35;
+         productRefGroup = OBJ_36;
          projectDirPath = ".";
          targets = (
-            OBJ_38,
-            OBJ_50,
+            OBJ_39,
+            OBJ_51,
          );
       };
       OBJ_10 = {
@@ -77,6 +77,7 @@
             OBJ_31,
             OBJ_32,
             OBJ_33,
+            OBJ_34,
          );
          name = "MessagePackTests";
          path = "Tests/MessagePackTests";
@@ -201,61 +202,57 @@
       };
       OBJ_32 = {
          isa = "PBXFileReference";
-         path = "StringTests.swift";
+         path = "RawTests.swift";
          sourceTree = "<group>";
       };
       OBJ_33 = {
          isa = "PBXFileReference";
-         path = "TrueTests.swift";
+         path = "StringTests.swift";
          sourceTree = "<group>";
       };
       OBJ_34 = {
          isa = "PBXFileReference";
+         path = "TrueTests.swift";
+         sourceTree = "<group>";
+      };
+      OBJ_35 = {
+         isa = "PBXFileReference";
          path = "Resources";
          sourceTree = "SOURCE_ROOT";
       };
-      OBJ_35 = {
+      OBJ_36 = {
          isa = "PBXGroup";
          children = (
-            OBJ_36,
             OBJ_37,
+            OBJ_38,
          );
          name = "Products";
          path = "";
          sourceTree = "BUILT_PRODUCTS_DIR";
       };
-      OBJ_36 = {
+      OBJ_37 = {
          isa = "PBXFileReference";
          path = "MessagePack.framework";
          sourceTree = "BUILT_PRODUCTS_DIR";
       };
-      OBJ_37 = {
+      OBJ_38 = {
          isa = "PBXFileReference";
          path = "MessagePackTests.xctest";
          sourceTree = "BUILT_PRODUCTS_DIR";
       };
-      OBJ_38 = {
+      OBJ_39 = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_39;
+         buildConfigurationList = OBJ_40;
          buildPhases = (
-            OBJ_42,
-            OBJ_49,
+            OBJ_43,
+            OBJ_50,
          );
          dependencies = (
          );
          name = "MessagePack";
          productName = "MessagePack";
-         productReference = OBJ_36;
+         productReference = OBJ_37;
          productType = "com.apple.product-type.framework";
-      };
-      OBJ_39 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_40,
-            OBJ_41,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
       };
       OBJ_4 = {
          isa = "XCBuildConfiguration";
@@ -289,33 +286,13 @@
          name = "Release";
       };
       OBJ_40 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-            );
-            INFOPLIST_FILE = "MessagePack.xcodeproj/MessagePack_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "MessagePack";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            TARGET_NAME = "MessagePack";
-         };
-         name = "Debug";
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            OBJ_41,
+            OBJ_42,
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Debug";
       };
       OBJ_41 = {
          isa = "XCBuildConfiguration";
@@ -344,88 +321,12 @@
             SKIP_INSTALL = "YES";
             TARGET_NAME = "MessagePack";
          };
-         name = "Release";
+         name = "Debug";
       };
       OBJ_42 = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            OBJ_43,
-            OBJ_44,
-            OBJ_45,
-            OBJ_46,
-            OBJ_47,
-            OBJ_48,
-         );
-      };
-      OBJ_43 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_9;
-      };
-      OBJ_44 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_10;
-      };
-      OBJ_45 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_11;
-      };
-      OBJ_46 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_12;
-      };
-      OBJ_47 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_13;
-      };
-      OBJ_48 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_14;
-      };
-      OBJ_49 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      OBJ_5 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_6,
-            OBJ_7,
-            OBJ_15,
-            OBJ_34,
-            OBJ_35,
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      OBJ_50 = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_51;
-         buildPhases = (
-            OBJ_54,
-            OBJ_72,
-         );
-         dependencies = (
-            OBJ_74,
-         );
-         name = "MessagePackTests";
-         productName = "MessagePackTests";
-         productReference = OBJ_37;
-         productType = "com.apple.product-type.bundle.unit-test";
-      };
-      OBJ_51 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_52,
-            OBJ_53,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_52 = {
          isa = "XCBuildConfiguration";
          buildSettings = {
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            ENABLE_TESTABILITY = "YES";
             FRAMEWORK_SEARCH_PATHS = (
                "$(inherited)",
                "$(PLATFORM_DIR)/Developer/Library/Frameworks",
@@ -433,10 +334,9 @@
             HEADER_SEARCH_PATHS = (
                "$(inherited)",
             );
-            INFOPLIST_FILE = "MessagePack.xcodeproj/MessagePackTests_Info.plist";
+            INFOPLIST_FILE = "MessagePack.xcodeproj/MessagePack_Info.plist";
             LD_RUNPATH_SEARCH_PATHS = (
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
             );
             OTHER_LDFLAGS = (
                "$(inherited)",
@@ -444,9 +344,89 @@
             OTHER_SWIFT_FLAGS = (
                "$(inherited)",
             );
-            TARGET_NAME = "MessagePackTests";
+            PRODUCT_BUNDLE_IDENTIFIER = "MessagePack";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            TARGET_NAME = "MessagePack";
          };
-         name = "Debug";
+         name = "Release";
+      };
+      OBJ_43 = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            OBJ_44,
+            OBJ_45,
+            OBJ_46,
+            OBJ_47,
+            OBJ_48,
+            OBJ_49,
+         );
+      };
+      OBJ_44 = {
+         isa = "PBXBuildFile";
+         fileRef = OBJ_9;
+      };
+      OBJ_45 = {
+         isa = "PBXBuildFile";
+         fileRef = OBJ_10;
+      };
+      OBJ_46 = {
+         isa = "PBXBuildFile";
+         fileRef = OBJ_11;
+      };
+      OBJ_47 = {
+         isa = "PBXBuildFile";
+         fileRef = OBJ_12;
+      };
+      OBJ_48 = {
+         isa = "PBXBuildFile";
+         fileRef = OBJ_13;
+      };
+      OBJ_49 = {
+         isa = "PBXBuildFile";
+         fileRef = OBJ_14;
+      };
+      OBJ_5 = {
+         isa = "PBXGroup";
+         children = (
+            OBJ_6,
+            OBJ_7,
+            OBJ_15,
+            OBJ_35,
+            OBJ_36,
+         );
+         path = "";
+         sourceTree = "<group>";
+      };
+      OBJ_50 = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      OBJ_51 = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = OBJ_52;
+         buildPhases = (
+            OBJ_55,
+            OBJ_74,
+         );
+         dependencies = (
+            OBJ_76,
+         );
+         name = "MessagePackTests";
+         productName = "MessagePackTests";
+         productReference = OBJ_38;
+         productType = "com.apple.product-type.bundle.unit-test";
+      };
+      OBJ_52 = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            OBJ_53,
+            OBJ_54,
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Debug";
       };
       OBJ_53 = {
          isa = "XCBuildConfiguration";
@@ -472,12 +452,37 @@
             );
             TARGET_NAME = "MessagePackTests";
          };
-         name = "Release";
+         name = "Debug";
       };
       OBJ_54 = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+            );
+            INFOPLIST_FILE = "MessagePack.xcodeproj/MessagePackTests_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks",
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+            );
+            TARGET_NAME = "MessagePackTests";
+         };
+         name = "Release";
+      };
+      OBJ_55 = {
          isa = "PBXSourcesBuildPhase";
          files = (
-            OBJ_55,
             OBJ_56,
             OBJ_57,
             OBJ_58,
@@ -494,27 +499,25 @@
             OBJ_69,
             OBJ_70,
             OBJ_71,
+            OBJ_72,
+            OBJ_73,
          );
-      };
-      OBJ_55 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_17;
       };
       OBJ_56 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_18;
+         fileRef = OBJ_17;
       };
       OBJ_57 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_19;
+         fileRef = OBJ_18;
       };
       OBJ_58 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_20;
+         fileRef = OBJ_19;
       };
       OBJ_59 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_21;
+         fileRef = OBJ_20;
       };
       OBJ_6 = {
          isa = "PBXFileReference";
@@ -524,43 +527,43 @@
       };
       OBJ_60 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_22;
+         fileRef = OBJ_21;
       };
       OBJ_61 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_23;
+         fileRef = OBJ_22;
       };
       OBJ_62 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_24;
+         fileRef = OBJ_23;
       };
       OBJ_63 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_25;
+         fileRef = OBJ_24;
       };
       OBJ_64 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_26;
+         fileRef = OBJ_25;
       };
       OBJ_65 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_27;
+         fileRef = OBJ_26;
       };
       OBJ_66 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_28;
+         fileRef = OBJ_27;
       };
       OBJ_67 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_29;
+         fileRef = OBJ_28;
       };
       OBJ_68 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_30;
+         fileRef = OBJ_29;
       };
       OBJ_69 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_31;
+         fileRef = OBJ_30;
       };
       OBJ_7 = {
          isa = "PBXGroup";
@@ -573,25 +576,33 @@
       };
       OBJ_70 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_32;
+         fileRef = OBJ_31;
       };
       OBJ_71 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_33;
+         fileRef = OBJ_32;
       };
       OBJ_72 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            OBJ_73,
-         );
+         isa = "PBXBuildFile";
+         fileRef = OBJ_33;
       };
       OBJ_73 = {
          isa = "PBXBuildFile";
-         fileRef = OBJ_36;
+         fileRef = OBJ_34;
       };
       OBJ_74 = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            OBJ_75,
+         );
+      };
+      OBJ_75 = {
+         isa = "PBXBuildFile";
+         fileRef = OBJ_37;
+      };
+      OBJ_76 = {
          isa = "PBXTargetDependency";
-         target = OBJ_38;
+         target = OBJ_39;
       };
       OBJ_8 = {
          isa = "PBXGroup";

--- a/MessagePack.xcodeproj/xcshareddata/xcschemes/MessagePack.xcscheme
+++ b/MessagePack.xcodeproj/xcshareddata/xcschemes/MessagePack.xcscheme
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "OBJ_50"
+               BlueprintIdentifier = "OBJ_51"
                BuildableName = "MessagePackTests.xctest"
                BlueprintName = "MessagePackTests"
                ReferencedContainer = "container:MessagePack.xcodeproj">

--- a/Sources/MessagePack/MessagePack.swift
+++ b/Sources/MessagePack/MessagePack.swift
@@ -13,6 +13,7 @@ public enum MessagePackValue {
     case array([MessagePackValue])
     case map([MessagePackValue: MessagePackValue])
     case extended(Int8, Data)
+    case raw(Data)
 }
 
 extension MessagePackValue: CustomStringConvertible {
@@ -40,6 +41,8 @@ extension MessagePackValue: CustomStringConvertible {
             return "map(\(dict.description))"
         case .extended(let type, let data):
             return "extended(\(type), \(data))"
+        case .raw(let data):
+            return "raw(\(data))"
         }
     }
 }
@@ -73,6 +76,8 @@ extension MessagePackValue: Equatable {
             return lhv == rhv
         case (.extended(let lht, let lhb), .extended(let rht, let rhb)):
             return lht == rht && lhb == rhb
+        case (.raw(let lhv), .raw(let rhv)):
+            return lhv == rhv
         default:
             return false
         }
@@ -93,6 +98,7 @@ extension MessagePackValue: Hashable {
         case .array(let array): return array.count
         case .map(let dict): return dict.count
         case .extended(let type, let data): return 31 &* type.hashValue &+ data.count
+        case .raw(let data): return data.count
         }
     }
 }

--- a/Sources/MessagePack/Pack.swift
+++ b/Sources/MessagePack/Pack.swift
@@ -174,5 +174,8 @@ public func pack(_ value: MessagePackValue) -> Data {
         }
 
         return prefix + data
+        
+    case .raw(let data):
+        return data
     }
 }

--- a/Tests/MessagePackTests/RawTests.swift
+++ b/Tests/MessagePackTests/RawTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import XCTest
+@testable import MessagePack
+
+class RawTests: XCTestCase {
+    static var allTests = {
+        return [
+            ("testPack", testPack),
+            ("testUnpack", testUnpack),
+        ]
+    }()
+
+    // the payload is an already message packed value
+    let payload = Data([0xA5, 0x68, 0x65, 0x6C, 0x6C, 0x6F])
+    let packed = Data([0xA5, 0x68, 0x65, 0x6C, 0x6C, 0x6F])
+
+    func testPack() {
+        XCTAssertEqual(pack(.raw(payload)), packed)
+    }
+
+    func testUnpack() {
+        let unpacked = try? unpack(packed)
+        XCTAssertEqual(unpacked?.value, .string("hello"))
+        XCTAssertEqual(unpacked?.remainder.count, 0)
+    }
+}


### PR DESCRIPTION
For data length calculation we pack data into a list until we hit a certain threshold. Then we take the packed values and put them into a MessagePack Array.

For this pre-packaging we introduced the `raw` type. It allows to have Bytes, that already represent MessagePack, and put them into another MessagePack.

It sounds similar to Binary, but it isn't the same: Binary marks the data explicitly as being binary and thus you'll also get a binary array back after unpack.

Raw, in contrast, does not add any marks and thus, if the raw bytes represent e.g. a `.string("hello")` after unpack, you won't get back the bytes you supplied, but `.string("hello")`.

Thank you for your great work and the time to take this PR into consideration.