### PR TITLE
Make `Numeric` convenience properties more strict in their type conversions

### DIFF
--- a/Sources/MessagePack/ConvenienceProperties.swift
+++ b/Sources/MessagePack/ConvenienceProperties.swift
@@ -43,7 +43,10 @@ extension MessagePackValue {
         }
     }
 
-    /// The integer value if `.Int` or an appropriately valued `.UInt`, `nil` otherwise.
+    // MARK: Signed integer values
+
+    /// The integer value if `.int` or an appropriately valued `.uint`, `nil` otherwise.
+    @available(*, deprecated, message: "use int64Value: instead")
     public var integerValue: Int64? {
         switch self {
         case .int(let value):
@@ -55,11 +58,144 @@ extension MessagePackValue {
         }
     }
 
-    /// The unsigned integer value if `.UInt` or positive `.Int`, `nil` otherwise.
+    /// The signed platform-dependent width integer value if `.int` or an
+    /// appropriately valued `.uint`, `nil` otherwise.
+    public var intValue: Int? {
+        switch self {
+        case .int(let value):
+            return Int(exactly: value)
+        case .uint(let value):
+            return Int(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    /// The signed 8-bit integer value if `.int` or an appropriately valued
+    /// `.uint`, `nil` otherwise.
+    public var int8Value: Int8? {
+        switch self {
+        case .int(let value):
+            return Int8(exactly: value)
+        case .uint(let value):
+            return Int8(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    /// The signed 16-bit integer value if `.int` or an appropriately valued
+    /// `.uint`, `nil` otherwise.
+    public var int16Value: Int16? {
+        switch self {
+        case .int(let value):
+            return Int16(exactly: value)
+        case .uint(let value):
+            return Int16(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    /// The signed 32-bit integer value if `.int` or an appropriately valued
+    /// `.uint`, `nil` otherwise.
+    public var int32Value: Int32? {
+        switch self {
+        case .int(let value):
+            return Int32(exactly: value)
+        case .uint(let value):
+            return Int32(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    /// The signed 64-bit integer value if `.int` or an appropriately valued
+    /// `.uint`, `nil` otherwise.
+    public var int64Value: Int64? {
+        switch self {
+        case .int(let value):
+            return value
+        case .uint(let value):
+            return Int64(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    // MARK: Unsigned integer values
+
+    /// The unsigned integer value if `.uint` or positive `.int`, `nil` otherwise.
+    @available(*, deprecated, message: "use uint64Value: instead")
     public var unsignedIntegerValue: UInt64? {
         switch self {
         case .int(let value) where value >= 0:
             return UInt64(value)
+        case .uint(let value):
+            return value
+        default:
+            return nil
+        }
+    }
+
+    /// The unsigned platform-dependent width integer value if `.uint` or an
+    /// appropriately valued `.int`, `nil` otherwise.
+    public var uintValue: UInt? {
+        switch self {
+        case .int(let value):
+            return UInt(exactly: value)
+        case .uint(let value):
+            return UInt(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    /// The unsigned 8-bit integer value if `.uint` or an appropriately valued
+    /// `.int`, `nil` otherwise.
+    public var uint8Value: UInt8? {
+        switch self {
+        case .int(let value):
+            return UInt8(exactly: value)
+        case .uint(let value):
+            return UInt8(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    /// The unsigned 16-bit integer value if `.uint` or an appropriately valued
+    /// `.int`, `nil` otherwise.
+    public var uint16Value: UInt16? {
+        switch self {
+        case .int(let value):
+            return UInt16(exactly: value)
+        case .uint(let value):
+            return UInt16(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    /// The unsigned 32-bit integer value if `.uint` or an appropriately valued
+    /// `.int`, `nil` otherwise.
+    public var uint32Value: UInt32? {
+        switch self {
+        case .int(let value):
+            return UInt32(exactly: value)
+        case .uint(let value):
+            return UInt32(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    /// The unsigned 64-bit integer value if `.uint` or an appropriately valued
+    /// `.int`, `nil` otherwise.
+    public var uint64Value: UInt64? {
+        switch self {
+        case .int(let value):
+            return UInt64(exactly: value)
         case .uint(let value):
             return value
         default:
@@ -93,7 +229,7 @@ extension MessagePackValue {
         case .float(let value):
             return value
         case .double(let value):
-            return Float(value)
+          return Float(exactly: value)
         default:
             return nil
         }
@@ -103,7 +239,7 @@ extension MessagePackValue {
     public var doubleValue: Double? {
         switch self {
         case .float(let value):
-            return Double(value)
+            return Double(exactly: value)
         case .double(let value):
             return value
         default:

--- a/Tests/MessagePackTests/ConveniencePropertiesTests.swift
+++ b/Tests/MessagePackTests/ConveniencePropertiesTests.swift
@@ -9,8 +9,16 @@ class ConveniencePropertiesTests: XCTestCase {
             ("testIndexedSubscript", testIndexedSubscript),
             ("testKeyedSubscript", testKeyedSubscript),
             ("testIsNil", testIsNil),
-            ("testIntegerValue", testIntegerValue),
-            ("testUnsignedIntegerValue", testUnsignedIntegerValue),
+            ("testIntValue", testIntValue),
+            ("testInt8Value", testInt8Value),
+            ("testInt16Value", testInt16Value),
+            ("testIn32Value", testInt32Value),
+            ("testInt64Value", testInt64Value),
+            ("testUIntValue", testUIntValue),
+            ("testUInt8Value", testUInt8Value),
+            ("testUInt16Value", testUInt16Value),
+            ("testUInt32Value", testUInt32Value),
+            ("testUInt64Value", testUInt64Value),
             ("testArrayValue", testArrayValue),
             ("testBoolValue", testBoolValue),
             ("testFloatValue", testFloatValue),
@@ -46,17 +54,98 @@ class ConveniencePropertiesTests: XCTestCase {
         XCTAssertFalse(MessagePackValue.bool(true).isNil)
     }
 
-    func testIntegerValue() {
-        XCTAssert(MessagePackValue.int(-1).integerValue == -1)
-        XCTAssert(MessagePackValue.uint(1).integerValue == 1)
-        XCTAssert(MessagePackValue.nil.integerValue == nil)
+    func testIntValue() {
+        XCTAssert(MessagePackValue.int(-1).intValue == -1)
+        XCTAssert(MessagePackValue.uint(1).intValue == 1)
+        XCTAssertNil(MessagePackValue.nil.intValue)
     }
 
-    func testUnsignedIntegerValue() {
-        XCTAssert(MessagePackValue.int(-1).unsignedIntegerValue == nil)
-        XCTAssert(MessagePackValue.int(1).unsignedIntegerValue == 1)
-        XCTAssert(MessagePackValue.uint(1).unsignedIntegerValue == 1)
-        XCTAssert(MessagePackValue.nil.unsignedIntegerValue == nil)
+    func testInt8Value() {
+        XCTAssert(MessagePackValue.int(-1).int8Value == -1)
+        XCTAssert(MessagePackValue.int(1).int8Value == 1)
+        XCTAssertNil(MessagePackValue.int(Int64(Int8.min) - 1).int8Value)
+        XCTAssertNil(MessagePackValue.int(Int64(Int8.max) + 1).int8Value)
+
+        XCTAssert(MessagePackValue.uint(1).int8Value == 1)
+        XCTAssertNil(MessagePackValue.uint(UInt64(Int8.max) + 1).int8Value)
+        XCTAssertNil(MessagePackValue.nil.int8Value)
+    }
+
+    func testInt16Value() {
+        XCTAssert(MessagePackValue.int(-1).int16Value == -1)
+        XCTAssert(MessagePackValue.int(1).int16Value == 1)
+        XCTAssertNil(MessagePackValue.int(Int64(Int16.min) - 1).int16Value)
+        XCTAssertNil(MessagePackValue.int(Int64(Int16.max) + 1).int16Value)
+
+        XCTAssert(MessagePackValue.uint(1).int16Value == 1)
+        XCTAssertNil(MessagePackValue.uint(UInt64(Int16.max) + 1).int16Value)
+        XCTAssertNil(MessagePackValue.nil.int16Value)
+    }
+
+    func testInt32Value() {
+        XCTAssert(MessagePackValue.int(-1).int32Value == -1)
+        XCTAssert(MessagePackValue.int(1).int32Value == 1)
+        XCTAssertNil(MessagePackValue.int(Int64(Int32.min) - 1).int32Value)
+        XCTAssertNil(MessagePackValue.int(Int64(Int32.max) + 1).int32Value)
+
+        XCTAssert(MessagePackValue.uint(1).int32Value == 1)
+        XCTAssertNil(MessagePackValue.uint(UInt64(Int32.max) + 1).int32Value)
+        XCTAssertNil(MessagePackValue.nil.int32Value)
+    }
+
+    func testInt64Value() {
+        XCTAssert(MessagePackValue.int(-1).int64Value == -1)
+        XCTAssert(MessagePackValue.int(1).int64Value == 1)
+
+        XCTAssert(MessagePackValue.uint(1).int64Value == 1)
+        XCTAssertNil(MessagePackValue.uint(UInt64(Int64.max) + 1).int64Value)
+        XCTAssertNil(MessagePackValue.nil.int64Value)
+    }
+
+    func testUIntValue() {
+        XCTAssert(MessagePackValue.uint(1).uintValue == 1)
+
+        XCTAssertNil(MessagePackValue.int(-1).uintValue)
+        XCTAssert(MessagePackValue.int(1).uintValue == 1)
+        XCTAssertNil(MessagePackValue.nil.uintValue)
+    }
+
+    func testUInt8Value() {
+        XCTAssert(MessagePackValue.uint(1).uint8Value == 1)
+        XCTAssertNil(MessagePackValue.uint(UInt64(UInt8.max) + 1).uint8Value)
+
+        XCTAssertNil(MessagePackValue.int(-1).uint8Value)
+        XCTAssert(MessagePackValue.int(1).uint8Value == 1)
+        XCTAssertNil(MessagePackValue.int(Int64(UInt8.max) + 1).uint8Value)
+        XCTAssertNil(MessagePackValue.nil.uint8Value)
+    }
+
+    func testUInt16Value() {
+        XCTAssert(MessagePackValue.uint(1).uint16Value == 1)
+        XCTAssertNil(MessagePackValue.uint(UInt64(UInt16.max) + 1).uint16Value)
+
+        XCTAssertNil(MessagePackValue.int(-1).uint16Value)
+        XCTAssert(MessagePackValue.int(1).uint16Value == 1)
+        XCTAssertNil(MessagePackValue.int(Int64(UInt16.max) + 1).uint16Value)
+        XCTAssertNil(MessagePackValue.nil.uint16Value)
+    }
+
+    func testUInt32Value() {
+        XCTAssert(MessagePackValue.uint(1).uint32Value == 1)
+        XCTAssertNil(MessagePackValue.uint(UInt64(UInt32.max) + 1).uint32Value)
+
+        XCTAssertNil(MessagePackValue.int(-1).uint32Value)
+        XCTAssert(MessagePackValue.int(1).uint32Value == 1)
+        XCTAssertNil(MessagePackValue.int(Int64(UInt32.max) + 1).uint32Value)
+        XCTAssertNil(MessagePackValue.nil.uint32Value)
+    }
+
+    func testUInt64Value() {
+        XCTAssert(MessagePackValue.uint(1).uint64Value == 1)
+
+        XCTAssertNil(MessagePackValue.int(-1).uint64Value)
+        XCTAssert(MessagePackValue.int(1).uint64Value == 1)
+        XCTAssertNil(MessagePackValue.nil.uint8Value)
     }
 
     func testArrayValue() {
@@ -80,8 +169,7 @@ class ConveniencePropertiesTests: XCTestCase {
         XCTAssertEqual(floatValue!, 3.14, accuracy: 0.0001)
 
         floatValue = MessagePackValue.double(3.14).floatValue
-        XCTAssertNotNil(floatValue)
-        XCTAssertEqual(floatValue!, 3.14, accuracy: 0.0001)
+        XCTAssertNil(floatValue)
     }
 
     func testDoubleValue() {


### PR DESCRIPTION
This pull request has arisen from my work on what is now an alternative implementation to pull request https://github.com/a2/MessagePack.swift/pull/61. I realized the need for more precision in the decoding process of integers (signed and unsigned) and floating point numbers. This patch does not modify the packing or unpacking process. It only provides a more robust and specific set of convenience properties for each width of integer, float, or double, requiring the value be exactly representable by the target type if the packed value is not already of the correct type. 

I believe this approach might result in less decoding errors. For example, previously, if you have a Double precision float point number, and accidentally invoke `MessagePackValue.floatValue` you would get back a nicely truncated float. This loss of precision could easily go unnoticed. Instead, `MessagePackValue.floatValue` will only return non-nil if the underlying `Double` can truly be represented by a float (in many cases, it cannot). While this might seem somewhat inconvenient initially, it offers a nice forcing function to ensure the correct data type is being decoded earlier in the development process. If one is okay with loss of precision, a simple truncating is no more difficult (but entirely more clear to the reader) than:

```swift
var value: MessagePackValue
Float(value.doubleValue)
```

I think this stricter typing in the convenience property API is more in line with the strict typing promoted by swift itself.