### PR TITLE
Permit 0 sized binary

### DIFF
--- a/Sources/MessagePack/Unpack.swift
+++ b/Sources/MessagePack/Unpack.swift
@@ -54,10 +54,6 @@ func unpackString(_ data: Subdata, count: Int) throws -> (value: String, remaind
 ///
 /// - returns: A subsection of data representing `size` bytes and the not-unpacked remaining data.
 func unpackData(_ data: Subdata, count: Int) throws -> (value: Subdata, remainder: Subdata) {
-    guard count > 0 else {
-        throw MessagePackError.invalidArgument
-    }
-
     guard data.count >= count else {
         throw MessagePackError.insufficientData
     }

--- a/Tests/MessagePackTests/BinaryTests.swift
+++ b/Tests/MessagePackTests/BinaryTests.swift
@@ -34,6 +34,21 @@ class BinaryTests: XCTestCase {
         XCTAssertEqual(unpacked?.remainder.count, 0)
     }
 
+    func testPackBinEmpty() {
+        let value = Data()
+        let expectedPacked = Data([0xc4, 0x00]) + value
+        XCTAssertEqual(pack(.binary(value)), expectedPacked)
+    }
+
+    func testUnpackBinEmpty() {
+        let data = Data()
+        let packed = Data([0xc4, 0x00]) + data
+
+        let unpacked = try? unpack(packed, compatibility: true)
+        XCTAssertEqual(unpacked?.value, MessagePackValue.binary(data))
+        XCTAssertEqual(unpacked?.remainder.count, 0)
+    }
+
     func testPackBin16() {
         let value = Data(count: 0xff)
         let expectedPacked = Data([0xc4, 0xff]) + value
@@ -135,4 +150,5 @@ class BinaryTests: XCTestCase {
         XCTAssertEqual(unpacked?.value, MessagePackValue.binary(data))
         XCTAssertEqual(unpacked?.remainder.count, 0)
     }
+
 }


### PR DESCRIPTION
Hello @a2 ,

Recently came across an incompatibility with msgpack-java.  I was encoding a binary array with variable size (0..n), and unpacking was throwing an exception for the 0 size case.  There's no explicit restriction in the spec that would forbid a 0 size binary, and both this library and the Java library will happily pack a zero-sized binary.  So I removed the assertion and added some basic tests.

This solves my problem, but it would be good to see this hit upstream.  Let me know what you think.

Cheers,

Jarrod